### PR TITLE
feat: impl strum::EnumIter for enums.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]
@@ -89,9 +89,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -243,12 +243,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "overload"
@@ -269,12 +266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,9 +273,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["cli", "core", "wasm"]
 
 [workspace.dependencies]
 base64 = "0.22.1"
-clap = { version = "4.5.19", features = ["derive", "env"] }
+clap = { version = "4.5.20", features = ["derive", "env"] }
 encoding_rs = "0.8.34"
 paste = "1.0.15"
 strum = { version = "0.26.3", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 
 .PHONY: doc
 doc:
-	cargo doc --open --workspace
+	cargo doc --open --workspace --no-deps
 
 .PHONY: fix
 fix:

--- a/core/src/converter/svg/util.rs
+++ b/core/src/converter/svg/util.rs
@@ -211,15 +211,15 @@ impl From<Pen> for Stroke {
                     stroke
                 }
                 PenStyle::PS_ENDCAP_SQUARE => {
-                    stroke.line_cap = "square".to_owned();
+                    "square".clone_into(&mut stroke.line_cap);
                     stroke
                 }
                 PenStyle::PS_JOIN_BEVEL => {
-                    stroke.line_join = "bevel".to_owned();
+                    "bevel".clone_into(&mut stroke.line_join);
                     stroke
                 }
                 PenStyle::PS_JOIN_MITER => {
-                    stroke.line_join = "miter".to_owned();
+                    "miter".clone_into(&mut stroke.line_join);
                     stroke
                 }
                 PenStyle::PS_SOLID => stroke,

--- a/core/src/parser/constants/enums/binary_raster_operation.rs
+++ b/core/src/parser/constants/enums/binary_raster_operation.rs
@@ -3,7 +3,15 @@
 /// processing combines the bits from the selected pen with the bits in the
 /// destination bitmap.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum BinaryRasterOperation {

--- a/core/src/parser/constants/enums/bit_count.rs
+++ b/core/src/parser/constants/enums/bit_count.rs
@@ -1,7 +1,15 @@
 /// The BitCount Enumeration specifies the number of bits that define each pixel
 /// and the maximum number of colors in a device-independent bitmap (DIB).
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum BitCount {

--- a/core/src/parser/constants/enums/brush_style.rs
+++ b/core/src/parser/constants/enums/brush_style.rs
@@ -2,7 +2,15 @@
 /// can be used in graphics operations. For more information, see the
 /// specification of the Brush Object.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum BrushStyle {

--- a/core/src/parser/constants/enums/character_set.rs
+++ b/core/src/parser/constants/enums/character_set.rs
@@ -1,7 +1,15 @@
 /// The CharacterSet Enumeration defines the possible sets of character glyphs
 /// that are defined in fonts for graphics output.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum CharacterSet {

--- a/core/src/parser/constants/enums/color_usage.rs
+++ b/core/src/parser/constants/enums/color_usage.rs
@@ -1,7 +1,15 @@
 /// The ColorUsage Enumeration specifies whether a color table exists in a
 /// device-independent bitmap (DIB) and how to interpret its values.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum ColorUsage {

--- a/core/src/parser/constants/enums/compression.rs
+++ b/core/src/parser/constants/enums/compression.rs
@@ -1,7 +1,15 @@
 /// The Compression Enumeration specifies the type of compression for a bitmap
 /// image.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u32)]
 pub enum Compression {

--- a/core/src/parser/constants/enums/family_font.rs
+++ b/core/src/parser/constants/enums/family_font.rs
@@ -2,7 +2,15 @@
 /// the look of a font in a general way. They are intended for specifying fonts
 /// when the exact typeface desired is not available.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum FamilyFont {

--- a/core/src/parser/constants/enums/flood_fill.rs
+++ b/core/src/parser/constants/enums/flood_fill.rs
@@ -1,7 +1,15 @@
 /// The FloodFill Enumeration specifies the type of fill operation to be
 /// performed.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum FloodFill {

--- a/core/src/parser/constants/enums/font_quality.rs
+++ b/core/src/parser/constants/enums/font_quality.rs
@@ -1,7 +1,15 @@
 /// The FontQuality Enumeration specifies how closely the attributes of the
 /// logical font match those of the physical font when rendering text.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum FontQuality {

--- a/core/src/parser/constants/enums/gamut_mapping_intent.rs
+++ b/core/src/parser/constants/enums/gamut_mapping_intent.rs
@@ -2,7 +2,15 @@
 /// logical and physical colors. (Windows NT 3.1, Windows NT 3.5, and Windows NT
 /// 3.51: This functionality is not supported.)
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u32)]
 pub enum GamutMappingIntent {

--- a/core/src/parser/constants/enums/hatch_style.rs
+++ b/core/src/parser/constants/enums/hatch_style.rs
@@ -1,6 +1,14 @@
 /// The HatchStyle Enumeration specifies the hatch pattern.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum HatchStyle {

--- a/core/src/parser/constants/enums/layout.rs
+++ b/core/src/parser/constants/enums/layout.rs
@@ -3,7 +3,15 @@
 /// NT 3.51, Windows 95, Windows NT 4.0, Windows 98, and Windows Millennium
 /// Edition: This functionality is not supported.)
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum Layout {

--- a/core/src/parser/constants/enums/logical_color_space.rs
+++ b/core/src/parser/constants/enums/logical_color_space.rs
@@ -6,7 +6,15 @@
 /// profile information for a DeviceIndependentBitmap (DIB) Object that has a
 /// header of type BitmapV5Header Object.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u32)]
 pub enum LogicalColorSpace {

--- a/core/src/parser/constants/enums/map_mode.rs
+++ b/core/src/parser/constants/enums/map_mode.rs
@@ -13,7 +13,15 @@
 /// logical coordinate (4,-5) would map to physical coordinate (0.04,0.05) in
 /// inches.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum MapMode {

--- a/core/src/parser/constants/enums/metafile_escapes.rs
+++ b/core/src/parser/constants/enums/metafile_escapes.rs
@@ -4,7 +4,15 @@
 ///
 /// These values are used by Escape Record Types.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum MetafileEscapes {

--- a/core/src/parser/constants/enums/metafile_type.rs
+++ b/core/src/parser/constants/enums/metafile_type.rs
@@ -1,6 +1,14 @@
 /// The MetafileType Enumeration specifies where the metafile is stored.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum MetafileType {

--- a/core/src/parser/constants/enums/metafile_version.rs
+++ b/core/src/parser/constants/enums/metafile_version.rs
@@ -1,7 +1,15 @@
 /// The MetafileVersion Enumeration defines values that specify support for
 /// device-independent bitmaps (DIBs) in metafiles.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum MetafileVersion {

--- a/core/src/parser/constants/enums/mix_mode.rs
+++ b/core/src/parser/constants/enums/mix_mode.rs
@@ -1,7 +1,15 @@
 /// The MixMode Enumeration specifies the background mix mode for text, hatched
 /// brushes, and other nonsolid pen styles.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum MixMode {

--- a/core/src/parser/constants/enums/out_precision.rs
+++ b/core/src/parser/constants/enums/out_precision.rs
@@ -3,7 +3,15 @@
 /// including height, width, character orientation, escapement, pitch, and font
 /// type.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum OutPrecision {

--- a/core/src/parser/constants/enums/palette_entry_flag.rs
+++ b/core/src/parser/constants/enums/palette_entry_flag.rs
@@ -1,6 +1,14 @@
 /// The PaletteEntryFlag Enumeration specifies how the palette entry is used.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum PaletteEntryFlag {

--- a/core/src/parser/constants/enums/pitch_font.rs
+++ b/core/src/parser/constants/enums/pitch_font.rs
@@ -5,7 +5,15 @@
 /// In a Font Object, when a FamilyFont Enumeration value is packed into a byte
 /// with a PitchFont value, the result is a PitchAndFamily Object.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum PitchFont {

--- a/core/src/parser/constants/enums/poly_fill_mode.rs
+++ b/core/src/parser/constants/enums/poly_fill_mode.rs
@@ -1,7 +1,15 @@
 /// The PolyFillMode Enumeration specifies the method used for filling a
 /// polygon.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum PolyFillMode {

--- a/core/src/parser/constants/enums/post_script_cap.rs
+++ b/core/src/parser/constants/enums/post_script_cap.rs
@@ -1,7 +1,15 @@
 /// The PostScriptCap Enumeration defines line-ending types for use with a
 /// PostScript printer driver.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(i32)]
 pub enum PostScriptCap {

--- a/core/src/parser/constants/enums/post_script_clipping.rs
+++ b/core/src/parser/constants/enums/post_script_clipping.rs
@@ -1,7 +1,15 @@
 /// The PostScriptClipping Enumeration defines functions that can be applied to
 /// the clipping path used for PostScript output.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum PostScriptClipping {

--- a/core/src/parser/constants/enums/post_script_feature_setting.rs
+++ b/core/src/parser/constants/enums/post_script_feature_setting.rs
@@ -3,7 +3,15 @@
 /// (Windows NT 3.1, Windows NT 3.5, Windows NT 3.51, Windows 95, Windows 98,
 /// and Windows Millennium Edition: This functionality is not supported.)
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u32)]
 pub enum PostScriptFeatureSetting {

--- a/core/src/parser/constants/enums/post_script_join.rs
+++ b/core/src/parser/constants/enums/post_script_join.rs
@@ -1,7 +1,15 @@
 /// The PostScriptJoin Enumeration defines line-joining capabilities for use
 /// with a PostScript printer driver.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(i32)]
 pub enum PostScriptJoin {

--- a/core/src/parser/constants/enums/record_type.rs
+++ b/core/src/parser/constants/enums/record_type.rs
@@ -1,7 +1,15 @@
 /// The RecordType Enumeration defines the types of records that can be used in
 /// WMF metafiles.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum RecordType {

--- a/core/src/parser/constants/enums/stretch_mode.rs
+++ b/core/src/parser/constants/enums/stretch_mode.rs
@@ -2,7 +2,15 @@
 /// defines how the system combines rows or columns of a bitmap with existing
 /// pixels.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum StretchMode {

--- a/core/src/parser/constants/enums/ternary_raster_operation.rs
+++ b/core/src/parser/constants/enums/ternary_raster_operation.rs
@@ -2,7 +2,15 @@
 /// codes, which define how to combine the bits in a source bitmap with the bits
 /// in a destination bitmap.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u32)]
 pub enum TernaryRasterOperation {

--- a/core/src/parser/constants/flags/clip_precision.rs
+++ b/core/src/parser/constants/flags/clip_precision.rs
@@ -2,7 +2,15 @@
 /// characters that are partially outside a clipping region. These flags can be
 /// combined to specify multiple options.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum ClipPrecision {

--- a/core/src/parser/constants/flags/ext_text_out_options.rs
+++ b/core/src/parser/constants/flags/ext_text_out_options.rs
@@ -1,7 +1,15 @@
 /// ExtTextOutOptions Flags specify various characteristics of the output of
 /// text. These flags can be combined to specify multiple options.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum ExtTextOutOptions {

--- a/core/src/parser/constants/flags/text_alignment_mode.rs
+++ b/core/src/parser/constants/flags/text_alignment_mode.rs
@@ -6,7 +6,15 @@
 /// Horizontal text alignment is performed when the font has a horizontal
 /// default baseline.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum TextAlignmentMode {

--- a/core/src/parser/constants/flags/vertical_text_alignment_mode.rs
+++ b/core/src/parser/constants/flags/vertical_text_alignment_mode.rs
@@ -7,7 +7,15 @@
 /// Vertical text alignment is performed when the font has a vertical default
 /// baseline, such as Kanji.
 #[derive(
-    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, strum::FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u16)]
 pub enum VerticalTextAlignmentMode {


### PR DESCRIPTION
## Abstract

- add derive macro `strum::EnumIter` for enums.
- fix clippy warnings.
- update dependencies.