### PR TITLE
chore: output error log as error level.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
  "shlex",
 ]
@@ -181,9 +181,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -273,9 +273,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -335,9 +335,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "same-file"
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -671,15 +671,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9"
+checksum = "d381749acb0943d357dcbd8f0b100640679883fcdeeef04def49daf8d33a5426"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
+checksum = "c97b2ef2c8d627381e51c071c2ab328eac606d3f69dd82bcbca20a9e389d95f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "time"] }
 tracing-wasm = "0.2.1"
 unicode-segmentation = "1.12.0"
-wasm-bindgen = "0.2.93"
-wasm-bindgen-test = "0.3.43"
+wasm-bindgen = "0.2.95"
+wasm-bindgen-test = "0.3.45"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/core/src/converter/mod.rs
+++ b/core/src/converter/mod.rs
@@ -51,7 +51,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn run(self) -> Result<(), ConvertError> {
         let Self { mut buffer, mut player } = self;

--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -75,7 +75,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn generate(self) -> Result<(), PlayError> {
         let Self { context_current, definitions, elements, mut output, .. } =
@@ -112,7 +112,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn selected_font(&self) -> Result<&Font, PlayError> {
         Ok(&self.object_selected.font)
@@ -126,7 +126,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn bit_blt(&mut self, record: META_BITBLT) -> Result<(), PlayError> {
         let operator = match record {
@@ -197,7 +197,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn device_independent_bitmap_bit_blt(
         &mut self,
@@ -271,7 +271,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn device_independent_bitmap_stretch_blt(
         &mut self,
@@ -345,7 +345,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_device_independent_bitmap_to_dev(
         &mut self,
@@ -358,7 +358,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn stretch_blt(
         &mut self,
@@ -432,7 +432,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn stretch_device_independent_bitmap(
         &mut self,
@@ -485,7 +485,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn eof(&mut self, _: META_EOF) -> Result<(), PlayError> {
         Ok(())
@@ -494,7 +494,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn header(&mut self, header: MetafileHeader) -> Result<(), PlayError> {
         let (_placeable, header) = match header {
@@ -522,7 +522,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn arc(&mut self, record: META_ARC) -> Result<(), PlayError> {
         let mut context = self.current_context().clone();
@@ -662,7 +662,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn chord(&mut self, record: META_CHORD) -> Result<(), PlayError> {
         tracing::info!("META_CHORD: not implemented");
@@ -672,7 +672,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn ellipse(&mut self, record: META_ELLIPSE) -> Result<(), PlayError> {
         let (rx, ry) = (
@@ -728,7 +728,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn ext_flood_fill(
         &mut self,
@@ -741,7 +741,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn ext_text_out(
         &mut self,
@@ -862,7 +862,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn fill_region(
         &mut self,
@@ -875,7 +875,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn flood_fill(&mut self, record: META_FLOODFILL) -> Result<(), PlayError> {
         tracing::info!("META_FLOODFILL: not implemented");
@@ -885,7 +885,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn frame_region(
         &mut self,
@@ -898,7 +898,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip(self),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn invert_region(
         &mut self,
@@ -911,7 +911,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn line_to(&mut self, record: META_LINETO) -> Result<(), PlayError> {
         let mut context = self.current_context().clone();
@@ -941,7 +941,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn paint_region(
         &mut self,
@@ -954,7 +954,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn pat_blt(&mut self, record: META_PATBLT) -> Result<(), PlayError> {
         if record.width == 0 || record.height == 0 {
@@ -994,7 +994,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn pie(&mut self, record: META_PIE) -> Result<(), PlayError> {
         let mut context = self.current_context().clone();
@@ -1070,7 +1070,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn polyline(&mut self, record: META_POLYLINE) -> Result<(), PlayError> {
         let mut context = self.current_context().clone();
@@ -1118,7 +1118,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn polygon(&mut self, record: META_POLYGON) -> Result<(), PlayError> {
         if record.number_of_points == 0 {
@@ -1171,7 +1171,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn poly_polygon(
         &mut self,
@@ -1240,7 +1240,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn reactangle(&mut self, record: META_RECTANGLE) -> Result<(), PlayError> {
         let mut context = self.current_context().clone();
@@ -1291,7 +1291,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn round_rect(&mut self, record: META_ROUNDRECT) -> Result<(), PlayError> {
         let (width, height) = (
@@ -1349,7 +1349,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_pixel(&mut self, _record: META_SETPIXEL) -> Result<(), PlayError> {
         tracing::info!("META_SETPIXEL: not implemented");
@@ -1359,7 +1359,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn text_out(&mut self, record: META_TEXTOUT) -> Result<(), PlayError> {
         let mut context = self.current_context().clone();
@@ -1411,7 +1411,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn create_brush_indirect(
         &mut self,
@@ -1428,7 +1428,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn create_font_indirect(
         &mut self,
@@ -1445,7 +1445,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn create_palette(
         &mut self,
@@ -1462,7 +1462,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn create_pattern_brush(
         &mut self,
@@ -1479,7 +1479,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn create_pen_indirect(
         &mut self,
@@ -1496,7 +1496,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn create_region(
         &mut self,
@@ -1513,7 +1513,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn delete_object(
         &mut self,
@@ -1530,7 +1530,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn create_device_independent_bitmap_pattern_brush(
         &mut self,
@@ -1547,7 +1547,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn select_clip_region(
         &mut self,
@@ -1560,7 +1560,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn select_object(
         &mut self,
@@ -1592,7 +1592,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn select_palette(
         &mut self,
@@ -1623,7 +1623,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn animate_palette(
         &mut self,
@@ -1636,7 +1636,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn exclude_clip_rect(
         &mut self,
@@ -1649,7 +1649,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn intersect_clip_rect(
         &mut self,
@@ -1671,7 +1671,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn move_to(&mut self, record: META_MOVETO) -> Result<(), PlayError> {
         let mut context = self.current_context().clone();
@@ -1687,7 +1687,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn offset_clip_region(
         &mut self,
@@ -1700,7 +1700,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn offset_viewport_origin(
         &mut self,
@@ -1713,7 +1713,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn offset_window_origin(
         &mut self,
@@ -1726,7 +1726,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn realize_palette(
         &mut self,
@@ -1739,7 +1739,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn resize_palette(
         &mut self,
@@ -1752,7 +1752,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn restore_device_context(
         &mut self,
@@ -1776,7 +1776,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn save_device_context(
         &mut self,
@@ -1790,7 +1790,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn scale_viewport_ext(
         &mut self,
@@ -1803,7 +1803,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn scale_window_ext(
         &mut self,
@@ -1825,7 +1825,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_bk_color(
         &mut self,
@@ -1841,7 +1841,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_bk_mode(&mut self, record: META_SETBKMODE) -> Result<(), PlayError> {
         self.set_current_context(
@@ -1854,7 +1854,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_layout(&mut self, _record: META_SETLAYOUT) -> Result<(), PlayError> {
         tracing::info!("META_SETLAYOUT: not implemented");
@@ -1864,7 +1864,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_map_mode(
         &mut self,
@@ -1880,7 +1880,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_mapper_flags(
         &mut self,
@@ -1893,7 +1893,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_pal_entries(
         &mut self,
@@ -1906,7 +1906,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_polyfill_mode(
         &mut self,
@@ -1924,7 +1924,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_relabs(&mut self, _record: META_SETRELABS) -> Result<(), PlayError> {
         tracing::info!("META_SETRELABS: reserved record and not supported");
@@ -1934,7 +1934,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_raster_operation(
         &mut self,
@@ -1950,7 +1950,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_stretch_blt_mode(
         &mut self,
@@ -1963,7 +1963,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_text_align(
         &mut self,
@@ -2000,7 +2000,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_text_char_extra(
         &mut self,
@@ -2013,7 +2013,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_text_color(
         &mut self,
@@ -2029,7 +2029,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_text_justification(
         &mut self,
@@ -2042,7 +2042,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_viewport_ext(
         &mut self,
@@ -2055,7 +2055,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_viewport_origin(
         &mut self,
@@ -2068,7 +2068,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_window_ext(
         &mut self,
@@ -2084,7 +2084,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn set_window_origin(
         &mut self,
@@ -2106,7 +2106,7 @@ where
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     fn escape(&mut self, _record: META_ESCAPE) -> Result<(), PlayError> {
         Ok(())

--- a/core/src/parser/constants/mod.rs
+++ b/core/src/parser/constants/mod.rs
@@ -25,7 +25,7 @@ macro_rules! impl_parser {
                 #[::tracing::instrument(
                     level = tracing::Level::TRACE,
                     skip_all,
-                    err(level = tracing::Level::DEBUG, Display),
+                    err(level = tracing::Level::ERROR, Display),
                 )]
                 pub fn parse<R: ::std::io::Read>(
                     buf: &mut R,

--- a/core/src/parser/objects/graphics/brush.rs
+++ b/core/src/parser/objects/graphics/brush.rs
@@ -24,7 +24,7 @@ impl Brush {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/graphics/font.rs
+++ b/core/src/parser/objects/graphics/font.rs
@@ -100,7 +100,7 @@ impl Font {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/graphics/palette.rs
+++ b/core/src/parser/objects/graphics/palette.rs
@@ -18,7 +18,7 @@ impl Palette {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/graphics/pen.rs
+++ b/core/src/parser/objects/graphics/pen.rs
@@ -17,7 +17,7 @@ impl Pen {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/graphics/region.rs
+++ b/core/src/parser/objects/graphics/region.rs
@@ -32,7 +32,7 @@ impl Region {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/bitmap16.rs
+++ b/core/src/parser/objects/structure/bitmap16.rs
@@ -47,7 +47,7 @@ impl Bitmap16 {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,
@@ -65,7 +65,7 @@ impl Bitmap16 {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse_without_bits<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/bitmap_info_header/core.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/core.rs
@@ -2,7 +2,7 @@ impl crate::parser::BitmapInfoHeader {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub(super) fn parse_as_core<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/bitmap_info_header/info.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/info.rs
@@ -2,7 +2,7 @@ impl crate::parser::BitmapInfoHeader {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub(super) fn parse_as_info<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/bitmap_info_header/v4.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/v4.rs
@@ -2,7 +2,7 @@ impl crate::parser::BitmapInfoHeader {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse_as_v4<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/bitmap_info_header/v5.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/v5.rs
@@ -2,7 +2,7 @@ impl crate::parser::BitmapInfoHeader {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse_as_v5<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/ciexyz.rs
+++ b/core/src/parser/objects/structure/ciexyz.rs
@@ -16,7 +16,7 @@ impl CIEXYZ {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/ciexyz_triple.rs
+++ b/core/src/parser/objects/structure/ciexyz_triple.rs
@@ -17,7 +17,7 @@ impl CIEXYZTriple {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/color_ref.rs
+++ b/core/src/parser/objects/structure/color_ref.rs
@@ -18,7 +18,7 @@ impl ColorRef {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/device_independent_bitmap.rs
+++ b/core/src/parser/objects/structure/device_independent_bitmap.rs
@@ -27,7 +27,7 @@ impl DeviceIndependentBitmap {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub(crate) fn parse_with_color_usage<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/log_brush.rs
+++ b/core/src/parser/objects/structure/log_brush.rs
@@ -20,7 +20,7 @@ impl LogBrush {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/log_color_space.rs
+++ b/core/src/parser/objects/structure/log_color_space.rs
@@ -52,7 +52,7 @@ impl LogColorSpace {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/log_color_space_w.rs
+++ b/core/src/parser/objects/structure/log_color_space_w.rs
@@ -52,7 +52,7 @@ impl LogColorSpaceW {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/palette_entry.rs
+++ b/core/src/parser/objects/structure/palette_entry.rs
@@ -21,7 +21,7 @@ impl PaletteEntry {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/pitch_and_family.rs
+++ b/core/src/parser/objects/structure/pitch_and_family.rs
@@ -15,7 +15,7 @@ impl PitchAndFamily {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/point_l.rs
+++ b/core/src/parser/objects/structure/point_l.rs
@@ -13,7 +13,7 @@ impl PointL {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/point_s.rs
+++ b/core/src/parser/objects/structure/point_s.rs
@@ -13,7 +13,7 @@ impl PointS {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/poly_polygon.rs
+++ b/core/src/parser/objects/structure/poly_polygon.rs
@@ -18,7 +18,7 @@ impl PolyPolygon {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/rect.rs
+++ b/core/src/parser/objects/structure/rect.rs
@@ -20,7 +20,7 @@ impl Rect {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/rect_l.rs
+++ b/core/src/parser/objects/structure/rect_l.rs
@@ -22,7 +22,7 @@ impl RectL {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/rgb_quad.rs
+++ b/core/src/parser/objects/structure/rgb_quad.rs
@@ -19,7 +19,7 @@ impl RGBQuad {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/scan.rs
+++ b/core/src/parser/objects/structure/scan.rs
@@ -26,7 +26,7 @@ impl Scan {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,
@@ -85,7 +85,7 @@ impl ScanLine {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/objects/structure/size_l.rs
+++ b/core/src/parser/objects/structure/size_l.rs
@@ -13,7 +13,7 @@ impl SizeL {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display)
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/bitmap/bit_blt.rs
+++ b/core/src/parser/records/bitmap/bit_blt.rs
@@ -105,7 +105,7 @@ impl META_BITBLT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/bitmap/dib_bit_blt.rs
+++ b/core/src/parser/records/bitmap/dib_bit_blt.rs
@@ -107,7 +107,7 @@ impl META_DIBBITBLT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/bitmap/dib_stretch_blt.rs
+++ b/core/src/parser/records/bitmap/dib_stretch_blt.rs
@@ -124,7 +124,7 @@ impl META_DIBSTRETCHBLT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/bitmap/set_dib_to_dev.rs
+++ b/core/src/parser/records/bitmap/set_dib_to_dev.rs
@@ -55,7 +55,7 @@ impl META_SETDIBTODEV {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/bitmap/stretch_blt.rs
+++ b/core/src/parser/records/bitmap/stretch_blt.rs
@@ -123,7 +123,7 @@ impl META_STRETCHBLT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/bitmap/stretch_dib.rs
+++ b/core/src/parser/records/bitmap/stretch_dib.rs
@@ -66,7 +66,7 @@ impl META_STRETCHDIB {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/control/eof.rs
+++ b/core/src/parser/records/control/eof.rs
@@ -19,7 +19,7 @@ impl META_EOF {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         _buf: &mut R,

--- a/core/src/parser/records/control/header.rs
+++ b/core/src/parser/records/control/header.rs
@@ -38,7 +38,7 @@ impl META_HEADER {
         level = tracing::Level::TRACE,
         skip_all,
         fields(key = %format!("{key:#010X}")),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub(in crate::parser::records::control) fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/control/mod.rs
+++ b/core/src/parser/records/control/mod.rs
@@ -20,7 +20,7 @@ impl MetafileHeader {
     #[tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/control/replaceable.rs
+++ b/core/src/parser/records/control/replaceable.rs
@@ -46,7 +46,7 @@ impl META_PLACEABLE {
         level = tracing::Level::TRACE,
         skip_all,
         fields(key = %format!("{key:#010X}")),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub(in crate::parser::records::control) fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/arc.rs
+++ b/core/src/parser/records/drawing/arc.rs
@@ -51,7 +51,7 @@ impl META_ARC {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/chord.rs
+++ b/core/src/parser/records/drawing/chord.rs
@@ -54,7 +54,7 @@ impl META_CHORD {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/ellipse.rs
+++ b/core/src/parser/records/drawing/ellipse.rs
@@ -38,7 +38,7 @@ impl META_ELLIPSE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/ext_flood_fill.rs
+++ b/core/src/parser/records/drawing/ext_flood_fill.rs
@@ -33,7 +33,7 @@ impl META_EXTFLOODFILL {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/ext_text_out.rs
+++ b/core/src/parser/records/drawing/ext_text_out.rs
@@ -60,7 +60,7 @@ impl META_EXTTEXTOUT {
             record_function = %format!("{record_function:#06X}"),
             ?charset,
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/fill_region.rs
+++ b/core/src/parser/records/drawing/fill_region.rs
@@ -25,7 +25,7 @@ impl META_FILLREGION {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/flood_fill.rs
+++ b/core/src/parser/records/drawing/flood_fill.rs
@@ -29,7 +29,7 @@ impl META_FLOODFILL {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/frame_region.rs
+++ b/core/src/parser/records/drawing/frame_region.rs
@@ -32,7 +32,7 @@ impl META_FRAMEREGION {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/invert_region.rs
+++ b/core/src/parser/records/drawing/invert_region.rs
@@ -23,7 +23,7 @@ impl META_INVERTREGION {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/line_to.rs
+++ b/core/src/parser/records/drawing/line_to.rs
@@ -27,7 +27,7 @@ impl META_LINETO {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/paint_region.rs
+++ b/core/src/parser/records/drawing/paint_region.rs
@@ -23,7 +23,7 @@ impl META_PAINTREGION {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/pat_blt.rs
+++ b/core/src/parser/records/drawing/pat_blt.rs
@@ -39,7 +39,7 @@ impl META_PATBLT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/pie.rs
+++ b/core/src/parser/records/drawing/pie.rs
@@ -53,7 +53,7 @@ impl META_PIE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/poly_line.rs
+++ b/core/src/parser/records/drawing/poly_line.rs
@@ -26,7 +26,7 @@ impl META_POLYLINE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/poly_polygon.rs
+++ b/core/src/parser/records/drawing/poly_polygon.rs
@@ -25,7 +25,7 @@ impl META_POLYPOLYGON {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/polygon.rs
+++ b/core/src/parser/records/drawing/polygon.rs
@@ -29,7 +29,7 @@ impl META_POLYGON {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/reactangle.rs
+++ b/core/src/parser/records/drawing/reactangle.rs
@@ -37,7 +37,7 @@ impl META_RECTANGLE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/round_rect.rs
+++ b/core/src/parser/records/drawing/round_rect.rs
@@ -43,7 +43,7 @@ impl META_ROUNDRECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/set_pixel.rs
+++ b/core/src/parser/records/drawing/set_pixel.rs
@@ -28,7 +28,7 @@ impl META_SETPIXEL {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/drawing/text_out.rs
+++ b/core/src/parser/records/drawing/text_out.rs
@@ -40,7 +40,7 @@ impl META_TEXTOUT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/escape/mod.rs
+++ b/core/src/parser/records/escape/mod.rs
@@ -835,7 +835,7 @@ impl META_ESCAPE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     #[allow(clippy::too_many_lines)]
     pub fn parse<R: std::io::Read>(

--- a/core/src/parser/records/mod.rs
+++ b/core/src/parser/records/mod.rs
@@ -48,7 +48,7 @@ impl RecordSize {
     #[::tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/create_brush_indirect.rs
+++ b/core/src/parser/records/object/create_brush_indirect.rs
@@ -25,7 +25,7 @@ impl META_CREATEBRUSHINDIRECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/create_font_indirect.rs
+++ b/core/src/parser/records/object/create_font_indirect.rs
@@ -21,7 +21,7 @@ impl META_CREATEFONTINDIRECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/create_palette.rs
+++ b/core/src/parser/records/object/create_palette.rs
@@ -22,7 +22,7 @@ impl META_CREATEPALETTE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/create_pattern_brush.rs
+++ b/core/src/parser/records/object/create_pattern_brush.rs
@@ -48,7 +48,7 @@ impl META_CREATEPATTERNBRUSH {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/create_pen_indirect.rs
+++ b/core/src/parser/records/object/create_pen_indirect.rs
@@ -21,7 +21,7 @@ impl META_CREATEPENINDIRECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/create_region.rs
+++ b/core/src/parser/records/object/create_region.rs
@@ -22,7 +22,7 @@ impl META_CREATEREGION {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/delete_object.rs
+++ b/core/src/parser/records/object/delete_object.rs
@@ -26,7 +26,7 @@ impl META_DELETEOBJECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/dib_create_pattern_brush.rs
+++ b/core/src/parser/records/object/dib_create_pattern_brush.rs
@@ -38,7 +38,7 @@ impl META_DIBCREATEPATTERNBRUSH {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/select_clip_region.rs
+++ b/core/src/parser/records/object/select_clip_region.rs
@@ -23,7 +23,7 @@ impl META_SELECTCLIPREGION {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/select_object.rs
+++ b/core/src/parser/records/object/select_object.rs
@@ -29,7 +29,7 @@ impl META_SELECTOBJECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/object/select_palette.rs
+++ b/core/src/parser/records/object/select_palette.rs
@@ -23,7 +23,7 @@ impl META_SELECTPALETTE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/animate_palette.rs
+++ b/core/src/parser/records/state/animate_palette.rs
@@ -32,7 +32,7 @@ impl META_ANIMATEPALETTE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/exclude_clip_rect.rs
+++ b/core/src/parser/records/state/exclude_clip_rect.rs
@@ -34,7 +34,7 @@ impl META_EXCLUDECLIPRECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/intersect_clip_rect.rs
+++ b/core/src/parser/records/state/intersect_clip_rect.rs
@@ -34,7 +34,7 @@ impl META_INTERSECTCLIPRECT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/move_to.rs
+++ b/core/src/parser/records/state/move_to.rs
@@ -26,7 +26,7 @@ impl META_MOVETO {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/offset_clip_rgn.rs
+++ b/core/src/parser/records/state/offset_clip_rgn.rs
@@ -26,7 +26,7 @@ impl META_OFFSETCLIPRGN {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/offset_viewport_org.rs
+++ b/core/src/parser/records/state/offset_viewport_org.rs
@@ -26,7 +26,7 @@ impl META_OFFSETVIEWPORTORG {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/offset_window_org.rs
+++ b/core/src/parser/records/state/offset_window_org.rs
@@ -26,7 +26,7 @@ impl META_OFFSETWINDOWORG {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/realize_palette.rs
+++ b/core/src/parser/records/state/realize_palette.rs
@@ -20,7 +20,7 @@ impl META_REALIZEPALETTE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/resize_palette.rs
+++ b/core/src/parser/records/state/resize_palette.rs
@@ -23,7 +23,7 @@ impl META_RESIZEPALETTE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/restore_dc.rs
+++ b/core/src/parser/records/state/restore_dc.rs
@@ -26,7 +26,7 @@ impl META_RESTOREDC {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/save_dc.rs
+++ b/core/src/parser/records/state/save_dc.rs
@@ -20,7 +20,7 @@ impl META_SAVEDC {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/scale_viewport_ext.rs
+++ b/core/src/parser/records/state/scale_viewport_ext.rs
@@ -35,7 +35,7 @@ impl META_SCALEVIEWPORTEXT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/scale_window_ext.rs
+++ b/core/src/parser/records/state/scale_window_ext.rs
@@ -35,7 +35,7 @@ impl META_SCALEWINDOWEXT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_bk_color.rs
+++ b/core/src/parser/records/state/set_bk_color.rs
@@ -24,7 +24,7 @@ impl META_SETBKCOLOR {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_bk_mode.rs
+++ b/core/src/parser/records/state/set_bk_mode.rs
@@ -29,7 +29,7 @@ impl META_SETBKMODE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_layout.rs
+++ b/core/src/parser/records/state/set_layout.rs
@@ -28,7 +28,7 @@ impl META_SETLAYOUT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_map_mode.rs
+++ b/core/src/parser/records/state/set_map_mode.rs
@@ -28,7 +28,7 @@ impl META_SETMAPMODE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_mapper_flags.rs
+++ b/core/src/parser/records/state/set_mapper_flags.rs
@@ -25,7 +25,7 @@ impl META_SETMAPPERFLAGS {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_pal_entries.rs
+++ b/core/src/parser/records/state/set_pal_entries.rs
@@ -23,7 +23,7 @@ impl META_SETPALENTRIES {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_polyfill_mode.rs
+++ b/core/src/parser/records/state/set_polyfill_mode.rs
@@ -28,7 +28,7 @@ impl META_SETPOLYFILLMODE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_relabs.rs
+++ b/core/src/parser/records/state/set_relabs.rs
@@ -19,7 +19,7 @@ impl META_SETRELABS {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_rop2.rs
+++ b/core/src/parser/records/state/set_rop2.rs
@@ -30,7 +30,7 @@ impl META_SETROP2 {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_stretch_blt_mode.rs
+++ b/core/src/parser/records/state/set_stretch_blt_mode.rs
@@ -28,7 +28,7 @@ impl META_SETSTRETCHBLTMODE {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_text_align.rs
+++ b/core/src/parser/records/state/set_text_align.rs
@@ -29,7 +29,7 @@ impl META_SETTEXTALIGN {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_text_char_extra.rs
+++ b/core/src/parser/records/state/set_text_char_extra.rs
@@ -28,7 +28,7 @@ impl META_SETTEXTCHAREXTRA {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_text_color.rs
+++ b/core/src/parser/records/state/set_text_color.rs
@@ -23,7 +23,7 @@ impl META_SETTEXTCOLOR {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_text_justification.rs
+++ b/core/src/parser/records/state/set_text_justification.rs
@@ -29,7 +29,7 @@ impl META_SETTEXTJUSTIFICATION {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_viewport_ext.rs
+++ b/core/src/parser/records/state/set_viewport_ext.rs
@@ -26,7 +26,7 @@ impl META_SETVIEWPORTEXT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_viewport_org.rs
+++ b/core/src/parser/records/state/set_viewport_org.rs
@@ -26,7 +26,7 @@ impl META_SETVIEWPORTORG {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_window_ext.rs
+++ b/core/src/parser/records/state/set_window_ext.rs
@@ -26,7 +26,7 @@ impl META_SETWINDOWEXT {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,

--- a/core/src/parser/records/state/set_window_org.rs
+++ b/core/src/parser/records/state/set_window_org.rs
@@ -26,7 +26,7 @@ impl META_SETWINDOWORG {
             %record_size,
             record_function = %format!("{record_function:#06X}"),
         ),
-        err(level = tracing::Level::DEBUG, Display),
+        err(level = tracing::Level::ERROR, Display),
     )]
     pub fn parse<R: std::io::Read>(
         buf: &mut R,


### PR DESCRIPTION
## Abstract

- use `ERROR` level to output error log in `tracing::instrument` .
- update dependencies.