### PR TITLE
chore: extract color palette into each pixels.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/src/converter/bitmap.rs
+++ b/core/src/converter/bitmap.rs
@@ -327,7 +327,7 @@ impl<'a> BitReader<'a> {
             }
 
             let bit = (self.data[self.byte_index] >> (7 - self.bit_index)) & 1;
-            value = (value << 1) | bit as u32;
+            value = (value << 1) | u32::from(bit);
 
             self.bit_index += 1;
             if self.bit_index >= 8 {

--- a/core/src/converter/svg/ternary_raster_operator.rs
+++ b/core/src/converter/svg/ternary_raster_operator.rs
@@ -84,7 +84,11 @@ impl TernaryRasterOperator {
                 .set("fill", "black"),
             TernaryRasterOperation::SRCCOPY => {
                 let bitmap = match self.source.unwrap() {
-                    Source::Bitmap16(data) => Bitmap::from(data),
+                    Source::Bitmap16(data) => {
+                        let bitmap =
+                            crate::parser::DeviceIndependentBitmap::from(data);
+                        crate::converter::Bitmap::from(bitmap)
+                    }
                     Source::Bitmap(data) => Bitmap::from(data),
                 };
 

--- a/core/src/converter/svg/util.rs
+++ b/core/src/converter/svg/util.rs
@@ -19,7 +19,7 @@ pub fn as_point_string(point: &PointS) -> String {
 impl crate::converter::Bitmap {
     pub fn as_data_url(&self) -> String {
         use base64::{engine::general_purpose::STANDARD, Engine};
-        format!("data:image/bmp;base64,{}", STANDARD.encode(&self.0))
+        format!("data:image/bmp;base64,{}", STANDARD.encode(self.as_slice()))
     }
 }
 
@@ -130,8 +130,10 @@ impl From<Brush> for Fill {
                 Fill::Pattern { pattern }
             }
             Brush::Pattern { brush_hatch } => {
-                let data = crate::converter::Bitmap::from(brush_hatch.clone())
-                    .as_data_url();
+                let bitmap = crate::parser::DeviceIndependentBitmap::from(
+                    brush_hatch.clone(),
+                );
+                let data = crate::converter::Bitmap::from(bitmap).as_data_url();
                 let image = Node::new("image")
                     .set("x", 0.to_string())
                     .set("y", 0.to_string())

--- a/core/src/parser/constants/enums/bit_count.rs
+++ b/core/src/parser/constants/enums/bit_count.rs
@@ -98,16 +98,3 @@ pub enum BitCount {
 }
 
 crate::parser::constants::impl_parser!(BitCount, u16);
-
-impl BitCount {
-    pub fn colors(&self) -> usize {
-        match self {
-            Self::BI_BITCOUNT_0 => 0,
-            Self::BI_BITCOUNT_1 => 2,
-            Self::BI_BITCOUNT_2 => 2usize.pow(4),
-            Self::BI_BITCOUNT_3 => 2usize.pow(8),
-            Self::BI_BITCOUNT_4 => 2usize.pow(16),
-            Self::BI_BITCOUNT_5 | Self::BI_BITCOUNT_6 => 2usize.pow(24),
-        }
-    }
-}

--- a/core/src/parser/constants/enums/gamut_mapping_intent.rs
+++ b/core/src/parser/constants/enums/gamut_mapping_intent.rs
@@ -14,14 +14,6 @@
 )]
 #[repr(u32)]
 pub enum GamutMappingIntent {
-    /// Specifies that the white point SHOULD be maintained. Typically used
-    /// when logical colors MUST be matched to their nearest physical color in
-    /// the destination color gamut.
-    ///
-    /// Intent: Match
-    ///
-    /// ICC name: Absolute Colorimetric
-    LCS_GM_ABS_COLORIMETRIC = 0x00000008,
     /// Specifies that saturation SHOULD be maintained. Typically used for
     /// business charts and other situations in which dithering is not
     /// required.
@@ -44,6 +36,14 @@ pub enum GamutMappingIntent {
     ///
     /// ICC name: Perceptual
     LCS_GM_IMAGES = 0x00000004,
+    /// Specifies that the white point SHOULD be maintained. Typically used
+    /// when logical colors MUST be matched to their nearest physical color in
+    /// the destination color gamut.
+    ///
+    /// Intent: Match
+    ///
+    /// ICC name: Absolute Colorimetric
+    LCS_GM_ABS_COLORIMETRIC = 0x00000008,
 }
 
 crate::parser::constants::impl_parser!(GamutMappingIntent, u32);

--- a/core/src/parser/objects/structure/bitmap_info_header/core.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/core.rs
@@ -1,12 +1,38 @@
 use crate::imports::*;
 
-impl crate::parser::BitmapInfoHeader {
+/// The BitmapCoreHeader Object contains information about the dimensions
+/// and color format of a device-independent bitmap (DIB). (Although
+/// Windows processes BitmapCoreHeader objects in DIBs, it does not
+/// write them to WMF metafiles)
+///
+/// A DIB is specified by a DeviceIndependentBitmap Object.
+#[derive(Clone, Debug)]
+pub struct BitmapInfoHeaderCore {
+    /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size of this object, in bytes.
+    pub header_size: u32,
+    /// Width (2 bytes): A 16-bit unsigned integer that defines the width
+    /// of the DIB, in pixels.
+    pub width: u16,
+    /// Height (2 bytes): A 16-bit unsigned integer that defines the height
+    /// of the DIB, in pixels.
+    pub height: u16,
+    /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
+    /// of planes for the target device. This value MUST be 0x0001.
+    pub planes: u16,
+    /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
+    /// format of each pixel, and the maximum number of colors in the DIB.
+    /// This value MUST be in the BitCount Enumeration.
+    pub bit_count: crate::parser::BitCount,
+}
+
+impl BitmapInfoHeaderCore {
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
         err(level = tracing::Level::ERROR, Display),
     ))]
-    pub(super) fn parse_as_core<R: crate::Read>(
+    pub(super) fn parse<R: crate::Read>(
         buf: &mut R,
         header_size: u32,
     ) -> Result<(Self, usize), crate::parser::ParseError> {
@@ -46,7 +72,7 @@ impl crate::parser::BitmapInfoHeader {
         }
 
         Ok((
-            Self::Core { header_size, width, height, planes, bit_count },
+            Self { header_size, width, height, planes, bit_count },
             consumed_bytes,
         ))
     }

--- a/core/src/parser/objects/structure/bitmap_info_header/info.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/info.rs
@@ -1,12 +1,96 @@
 use crate::imports::*;
 
-impl crate::parser::BitmapInfoHeader {
+/// The BitmapInfoHeader Object contains information about the dimensions
+/// and color format of a device-independent bitmap (DIB).
+#[derive(Clone, Debug)]
+pub struct BitmapInfoHeaderInfo {
+    /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size of this object, in bytes.
+    pub header_size: u32,
+    /// Width (4 bytes): A 32-bit signed integer that defines the width of
+    /// the DIB, in pixels. This value MUST be positive.
+    ///
+    /// This field SHOULD specify the width of the decompressed image file,
+    /// if the Compression value specifies JPEG or PNG format. (Windows NT
+    /// 3.1, Windows NT 3.5, Windows NT 3.51, Windows 95, and Windows NT
+    /// 4.0: Neither JPEG nor PNG format is supported.)
+    pub width: i32,
+    /// Height (4 bytes): A 32-bit signed integer that defines the height
+    /// of the DIB, in pixels. This value MUST NOT be zero.
+    ///
+    /// | Value | Meaning |
+    /// |-|-|
+    /// | 0x00000000 < value | If this value is positive, the DIB is a bottom-up bitmap, and its origin is the lower-left corner. This field SHOULD specify the height of the decompressed image file, if the Compression value specifies JPEG or PNG format. |
+    /// | value < 0x00000000 | If this value is negative, the DIB is a top-down bitmap, and its origin is the upper-left corner. Top-down bitmaps do not support compression. |
+    pub height: i32,
+    /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
+    /// of planes for the target device. This value MUST be 0x0001.
+    pub planes: u16,
+    /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
+    /// number of bits that define each pixel and the maximum number of
+    /// colors in the DIB. This value MUST be in the BitCount Enumeration.
+    pub bit_count: crate::parser::BitCount,
+    /// Compression (4 bytes): A 32-bit unsigned integer that defines the
+    /// compression mode of the DIB. This value MUST be in the Compression
+    /// Enumeration.
+    ///
+    /// This value MUST NOT specify a compressed format if the DIB is a
+    /// top-down bitmap, as indicated by the Height value.
+    pub compression: crate::parser::Compression,
+    /// ImageSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size, in bytes, of the image.
+    ///
+    /// If the Compression value is BI_RGB, this value SHOULD be zero and
+    /// MUST be ignored. (Windows implementations might write a nonzero
+    /// value to this field, but it is ignored when the metafile is
+    /// parsed.)
+    ///
+    /// If the Compression value is BI_JPEG or BI_PNG, this value MUST
+    /// specify the size of the JPEG or PNG image buffer, respectively.
+    pub image_size: u32,
+    /// XPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
+    /// horizontal resolution, in pixels-per-meter, of the target device
+    /// for the DIB.
+    pub x_pels_per_meter: i32,
+    /// YPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
+    /// vertical resolution, in pixels-per-meter, of the target device for
+    /// the DIB.
+    pub y_pels_per_meter: i32,
+    /// ColorUsed (4 bytes): A 32-bit unsigned integer that specifies the
+    /// number of indexes in the color table used by the DIB, as follows:
+    ///
+    /// - If this value is zero, the DIB uses the maximum number of colors that
+    ///   correspond to the BitCount value.
+    /// - If this value is nonzero and the BitCount value is less than 16, this
+    ///   value specifies the number of colors used by the DIB.
+    /// - If this value is nonzero and the BitCount value is 16 or greater,
+    ///   this value specifies the size of the color table used to optimize
+    ///   performance of the system palette.
+    ///
+    /// Note If this value is nonzero and greater than the maximum possible
+    /// size of the color table based on the BitCount value, the maximum
+    /// color table size SHOULD be assumed.
+    pub color_used: u32,
+    /// ColorImportant (4 bytes): A 32-bit unsigned integer that defines
+    /// the number of color indexes that are required for displaying the
+    /// DIB. If this value is zero, all color indexes are required.
+    ///
+    /// A DIB is specified by a DeviceIndependentBitmap Object.
+    ///
+    /// When the array of pixels in the DIB immediately follows the
+    /// BitmapInfoHeader, the DIB is a packed bitmap. In a packed bitmap,
+    /// the ColorUsed value MUST be either 0x00000000 or the actual size of
+    /// the color table.
+    pub color_important: u32,
+}
+
+impl BitmapInfoHeaderInfo {
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
         err(level = tracing::Level::ERROR, Display),
     ))]
-    pub(super) fn parse_as_info<R: crate::Read>(
+    pub(super) fn parse<R: crate::Read>(
         buf: &mut R,
         header_size: u32,
     ) -> Result<(Self, usize), crate::parser::ParseError> {
@@ -63,7 +147,7 @@ impl crate::parser::BitmapInfoHeader {
         }
 
         Ok((
-            Self::Info {
+            Self {
                 header_size,
                 width,
                 height,

--- a/core/src/parser/objects/structure/bitmap_info_header/mod.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/mod.rs
@@ -3,412 +3,14 @@ mod info;
 mod v4;
 mod v5;
 
+pub use self::{core::*, info::*, v4::*, v5::*};
+
 #[derive(Clone, Debug)]
 pub enum BitmapInfoHeader {
-    /// The BitmapCoreHeader Object contains information about the dimensions
-    /// and color format of a device-independent bitmap (DIB). (Although
-    /// Windows processes BitmapCoreHeader objects in DIBs, it does not
-    /// write them to WMF metafiles)
-    ///
-    /// A DIB is specified by a DeviceIndependentBitmap Object.
-    Core {
-        /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size of this object, in bytes.
-        header_size: u32,
-        /// Width (2 bytes): A 16-bit unsigned integer that defines the width
-        /// of the DIB, in pixels.
-        width: u16,
-        /// Height (2 bytes): A 16-bit unsigned integer that defines the height
-        /// of the DIB, in pixels.
-        height: u16,
-        /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
-        /// of planes for the target device. This value MUST be 0x0001.
-        planes: u16,
-        /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
-        /// format of each pixel, and the maximum number of colors in the DIB.
-        /// This value MUST be in the BitCount Enumeration.
-        bit_count: crate::parser::BitCount,
-    },
-    /// The BitmapInfoHeader Object contains information about the dimensions
-    /// and color format of a device-independent bitmap (DIB).
-    Info {
-        /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size of this object, in bytes.
-        header_size: u32,
-        /// Width (4 bytes): A 32-bit signed integer that defines the width of
-        /// the DIB, in pixels. This value MUST be positive.
-        ///
-        /// This field SHOULD specify the width of the decompressed image file,
-        /// if the Compression value specifies JPEG or PNG format. (Windows NT
-        /// 3.1, Windows NT 3.5, Windows NT 3.51, Windows 95, and Windows NT
-        /// 4.0: Neither JPEG nor PNG format is supported.)
-        width: i32,
-        /// Height (4 bytes): A 32-bit signed integer that defines the height
-        /// of the DIB, in pixels. This value MUST NOT be zero.
-        ///
-        /// | Value | Meaning |
-        /// |-|-|
-        /// | 0x00000000 < value | If this value is positive, the DIB is a bottom-up bitmap, and its origin is the lower-left corner. This field SHOULD specify the height of the decompressed image file, if the Compression value specifies JPEG or PNG format. |
-        /// | value < 0x00000000 | If this value is negative, the DIB is a top-down bitmap, and its origin is the upper-left corner. Top-down bitmaps do not support compression. |
-        height: i32,
-        /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
-        /// of planes for the target device. This value MUST be 0x0001.
-        planes: u16,
-        /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
-        /// number of bits that define each pixel and the maximum number of
-        /// colors in the DIB. This value MUST be in the BitCount Enumeration.
-        bit_count: crate::parser::BitCount,
-        /// Compression (4 bytes): A 32-bit unsigned integer that defines the
-        /// compression mode of the DIB. This value MUST be in the Compression
-        /// Enumeration.
-        ///
-        /// This value MUST NOT specify a compressed format if the DIB is a
-        /// top-down bitmap, as indicated by the Height value.
-        compression: crate::parser::Compression,
-        /// ImageSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size, in bytes, of the image.
-        ///
-        /// If the Compression value is BI_RGB, this value SHOULD be zero and
-        /// MUST be ignored. (Windows implementations might write a nonzero
-        /// value to this field, but it is ignored when the metafile is
-        /// parsed.)
-        ///
-        /// If the Compression value is BI_JPEG or BI_PNG, this value MUST
-        /// specify the size of the JPEG or PNG image buffer, respectively.
-        image_size: u32,
-        /// XPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
-        /// horizontal resolution, in pixels-per-meter, of the target device
-        /// for the DIB.
-        x_pels_per_meter: i32,
-        /// YPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
-        /// vertical resolution, in pixels-per-meter, of the target device for
-        /// the DIB.
-        y_pels_per_meter: i32,
-        /// ColorUsed (4 bytes): A 32-bit unsigned integer that specifies the
-        /// number of indexes in the color table used by the DIB, as follows:
-        ///
-        /// - If this value is zero, the DIB uses the maximum number of colors
-        ///   that correspond to the BitCount value.
-        /// - If this value is nonzero and the BitCount value is less than 16,
-        ///   this value specifies the number of colors used by the DIB.
-        /// - If this value is nonzero and the BitCount value is 16 or greater,
-        ///   this value specifies the size of the color table used to optimize
-        ///   performance of the system palette.
-        ///
-        /// Note If this value is nonzero and greater than the maximum possible
-        /// size of the color table based on the BitCount value, the maximum
-        /// color table size SHOULD be assumed.
-        color_used: u32,
-        /// ColorImportant (4 bytes): A 32-bit unsigned integer that defines
-        /// the number of color indexes that are required for displaying the
-        /// DIB. If this value is zero, all color indexes are required.
-        ///
-        /// A DIB is specified by a DeviceIndependentBitmap Object.
-        ///
-        /// When the array of pixels in the DIB immediately follows the
-        /// BitmapInfoHeader, the DIB is a packed bitmap. In a packed bitmap,
-        /// the ColorUsed value MUST be either 0x00000000 or the actual size of
-        /// the color table.
-        color_important: u32,
-    },
-    /// The BitmapV4Header Object contains information about the dimensions and
-    /// color format of a device-independent bitmap (DIB). It is an extension
-    /// of the BitmapInfoHeader Object. (Windows NT 3.1, Windows NT 3.5, and
-    /// Windows NT 3.51: This structure is not supported.)
-    V4 {
-        /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size of this object, in bytes.
-        header_size: u32,
-        /// Width (4 bytes): A 32-bit signed integer that defines the width of
-        /// the DIB, in pixels. This value MUST be positive.
-        ///
-        /// This field SHOULD specify the width of the decompressed image file,
-        /// if the Compression value specifies JPEG or PNG format. (Windows NT
-        /// 3.1, Windows NT 3.5, Windows NT 3.51, Windows 95, and Windows NT
-        /// 4.0: Neither JPEG nor PNG format is supported.)
-        width: i32,
-        /// Height (4 bytes): A 32-bit signed integer that defines the height
-        /// of the DIB, in pixels. This value MUST NOT be zero.
-        ///
-        /// | Value | Meaning |
-        /// |-|-|
-        /// | 0x00000000 < value | If this value is positive, the DIB is a bottom-up bitmap, and its origin is the lower-left corner. This field SHOULD specify the height of the decompressed image file, if the Compression value specifies JPEG or PNG format. |
-        /// | value < 0x00000000 | If this value is negative, the DIB is a top-down bitmap, and its origin is the upper-left corner. Top-down bitmaps do not support compression. |
-        height: i32,
-        /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
-        /// of planes for the target device. This value MUST be 0x0001.
-        planes: u16,
-        /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
-        /// number of bits that define each pixel and the maximum number of
-        /// colors in the DIB. This value MUST be in the BitCount Enumeration.
-        bit_count: crate::parser::BitCount,
-        /// Compression (4 bytes): A 32-bit unsigned integer that defines the
-        /// compression mode of the DIB. This value MUST be in the Compression
-        /// Enumeration.
-        ///
-        /// This value MUST NOT specify a compressed format if the DIB is a
-        /// top-down bitmap, as indicated by the Height value.
-        compression: crate::parser::Compression,
-        /// ImageSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size, in bytes, of the image.
-        ///
-        /// If the Compression value is BI_RGB, this value SHOULD be zero and
-        /// MUST be ignored. (Windows implementations might write a nonzero
-        /// value to this field, but it is ignored when the metafile is
-        /// parsed.)
-        ///
-        /// If the Compression value is BI_JPEG or BI_PNG, this value MUST
-        /// specify the size of the JPEG or PNG image buffer, respectively.
-        image_size: u32,
-        /// XPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
-        /// horizontal resolution, in pixels-per-meter, of the target device
-        /// for the DIB.
-        x_pels_per_meter: i32,
-        /// YPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
-        /// vertical resolution, in pixels-per-meter, of the target device for
-        /// the DIB.
-        y_pels_per_meter: i32,
-        /// ColorUsed (4 bytes): A 32-bit unsigned integer that specifies the
-        /// number of indexes in the color table used by the DIB, as follows:
-        ///
-        /// - If this value is zero, the DIB uses the maximum number of colors
-        ///   that correspond to the BitCount value.
-        /// - If this value is nonzero and the BitCount value is less than 16,
-        ///   this value specifies the number of colors used by the DIB.
-        /// - If this value is nonzero and the BitCount value is 16 or greater,
-        ///   this value specifies the size of the color table used to optimize
-        ///   performance of the system palette.
-        ///
-        /// Note If this value is nonzero and greater than the maximum possible
-        /// size of the color table based on the BitCount value, the maximum
-        /// color table size SHOULD be assumed.
-        color_used: u32,
-        /// ColorImportant (4 bytes): A 32-bit unsigned integer that defines
-        /// the number of color indexes that are required for displaying the
-        /// DIB. If this value is zero, all color indexes are required.
-        ///
-        /// A DIB is specified by a DeviceIndependentBitmap Object.
-        ///
-        /// When the array of pixels in the DIB immediately follows the
-        /// BitmapInfoHeader, the DIB is a packed bitmap. In a packed bitmap,
-        /// the ColorUsed value MUST be either 0x00000000 or the actual size of
-        /// the color table.
-        color_important: u32,
-        /// RedMask (4 bytes): A 32-bit unsigned integer that defines the color
-        /// mask that specifies the red component of each pixel. If the
-        /// Compression value in the BitmapInfoHeader object is not
-        /// BI_BITFIELDS, this value MUST be ignored.
-        red_mask: u32,
-        /// GreenMask (4 bytes): A 32-bit unsigned integer that defines the
-        /// color mask that specifies the green component of each pixel. If the
-        /// Compression value in the BitmapInfoHeader object is not
-        /// BI_BITFIELDS, this value MUST be ignored.
-        green_mask: u32,
-        /// BlueMask (4 bytes): A 32-bit unsigned integer that defines the
-        /// color mask that specifies the blue component of each pixel. If the
-        /// Compression value in the BitmapInfoHeader object is not
-        /// BI_BITFIELDS, this value MUST be ignored.
-        blue_mask: u32,
-        /// AlphaMask (4 bytes): A 32-bit unsigned integer that defines the
-        /// color mask that specifies the alpha component of each pixel.
-        alpha_mask: u32,
-        /// ColorSpaceType (4 bytes): A 32-bit unsigned integer that defines
-        /// the color space of the DeviceIndependentBitmap Object. If this
-        /// value is LCS_CALIBRATED_RGB from the LogicalColorSpace Enumeration,
-        /// the color values in the DIB are calibrated RGB values, and the
-        /// endpoints and gamma values in this structure SHOULD be used to
-        /// translate the color values before they are passed to the device.
-        ///
-        /// See the LogColorSpace and LogColorSpace ObjectW objects for details
-        /// concerning a logical color space.
-        color_space_type: crate::parser::LogicalColorSpace,
-        /// Endpoints (36 bytes): A CIEXYZTriple Object that defines the CIE
-        /// chromaticity x, y, and z coordinates of the three colors that
-        /// correspond to the red, green, and blue endpoints for the logical
-        /// color space associated with the DIB. If the ColorSpaceType field
-        /// does not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        endpoints: crate::parser::CIEXYZTriple,
-        /// GammaRed (4 bytes): A 32-bit fixed point value that defines the
-        /// toned response curve for red. If the ColorSpaceType field does not
-        /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        gamma_red: u32,
-        /// GammaGreen (4 bytes): A 32-bit fixed point value that defines the
-        /// toned response curve for green. If the ColorSpaceType field does
-        /// not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        gamma_green: u32,
-        /// GammaBlue (4 bytes): A 32-bit fixed point value that defines the
-        /// toned response curve for blue. If the ColorSpaceType field does not
-        /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        ///
-        /// The gamma value format is an unsigned "8.8" fixed-point integer
-        /// that is then left-shifted by 8 bits. "8.8" means "8 integer bits
-        /// followed by 8 fraction bits": nnnnnnnnffffffff. Taking the shift
-        /// into account, the required format of the 32-bit DWORD is:
-        /// 00000000nnnnnnnnffffffff00000000.
-        gamma_blue: u32,
-    },
-    /// The BitmapV5Header Object contains information about the dimensions and
-    /// color format of a device-independent bitmap (DIB). It is an extension
-    /// of the BitmapV4Header Object. (Windows NT 3.1, Windows NT 3.5, Windows
-    /// NT 3.51, Windows 95, and Windows NT 4.0: This structure is not
-    /// supported.)
-    V5 {
-        /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size of this object, in bytes.
-        header_size: u32,
-        /// Width (4 bytes): A 32-bit signed integer that defines the width of
-        /// the DIB, in pixels. This value MUST be positive.
-        ///
-        /// This field SHOULD specify the width of the decompressed image file,
-        /// if the Compression value specifies JPEG or PNG format. (Windows NT
-        /// 3.1, Windows NT 3.5, Windows NT 3.51, Windows 95, and Windows NT
-        /// 4.0: Neither JPEG nor PNG format is supported.)
-        width: i32,
-        /// Height (4 bytes): A 32-bit signed integer that defines the height
-        /// of the DIB, in pixels. This value MUST NOT be zero.
-        ///
-        /// | Value | Meaning |
-        /// |-|-|
-        /// | 0x00000000 < value | If this value is positive, the DIB is a bottom-up bitmap, and its origin is the lower-left corner. This field SHOULD specify the height of the decompressed image file, if the Compression value specifies JPEG or PNG format. |
-        /// | value < 0x00000000 | If this value is negative, the DIB is a top-down bitmap, and its origin is the upper-left corner. Top-down bitmaps do not support compression. |
-        height: i32,
-        /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
-        /// of planes for the target device. This value MUST be 0x0001.
-        planes: u16,
-        /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
-        /// number of bits that define each pixel and the maximum number of
-        /// colors in the DIB. This value MUST be in the BitCount Enumeration.
-        bit_count: crate::parser::BitCount,
-        /// Compression (4 bytes): A 32-bit unsigned integer that defines the
-        /// compression mode of the DIB. This value MUST be in the Compression
-        /// Enumeration.
-        ///
-        /// This value MUST NOT specify a compressed format if the DIB is a
-        /// top-down bitmap, as indicated by the Height value.
-        compression: crate::parser::Compression,
-        /// ImageSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size, in bytes, of the image.
-        ///
-        /// If the Compression value is BI_RGB, this value SHOULD be zero and
-        /// MUST be ignored. (Windows implementations might write a nonzero
-        /// value to this field, but it is ignored when the metafile is
-        /// parsed.)
-        ///
-        /// If the Compression value is BI_JPEG or BI_PNG, this value MUST
-        /// specify the size of the JPEG or PNG image buffer, respectively.
-        image_size: u32,
-        /// XPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
-        /// horizontal resolution, in pixels-per-meter, of the target device
-        /// for the DIB.
-        x_pels_per_meter: i32,
-        /// YPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
-        /// vertical resolution, in pixels-per-meter, of the target device for
-        /// the DIB.
-        y_pels_per_meter: i32,
-        /// ColorUsed (4 bytes): A 32-bit unsigned integer that specifies the
-        /// number of indexes in the color table used by the DIB, as follows:
-        ///
-        /// - If this value is zero, the DIB uses the maximum number of colors
-        ///   that correspond to the BitCount value.
-        /// - If this value is nonzero and the BitCount value is less than 16,
-        ///   this value specifies the number of colors used by the DIB.
-        /// - If this value is nonzero and the BitCount value is 16 or greater,
-        ///   this value specifies the size of the color table used to optimize
-        ///   performance of the system palette.
-        ///
-        /// Note If this value is nonzero and greater than the maximum possible
-        /// size of the color table based on the BitCount value, the maximum
-        /// color table size SHOULD be assumed.
-        color_used: u32,
-        /// ColorImportant (4 bytes): A 32-bit unsigned integer that defines
-        /// the number of color indexes that are required for displaying the
-        /// DIB. If this value is zero, all color indexes are required.
-        ///
-        /// A DIB is specified by a DeviceIndependentBitmap Object.
-        ///
-        /// When the array of pixels in the DIB immediately follows the
-        /// BitmapInfoHeader, the DIB is a packed bitmap. In a packed bitmap,
-        /// the ColorUsed value MUST be either 0x00000000 or the actual size of
-        /// the color table.
-        color_important: u32,
-        /// RedMask (4 bytes): A 32-bit unsigned integer that defines the color
-        /// mask that specifies the red component of each pixel. If the
-        /// Compression value in the BitmapInfoHeader object is not
-        /// BI_BITFIELDS, this value MUST be ignored.
-        red_mask: u32,
-        /// GreenMask (4 bytes): A 32-bit unsigned integer that defines the
-        /// color mask that specifies the green component of each pixel. If the
-        /// Compression value in the BitmapInfoHeader object is not
-        /// BI_BITFIELDS, this value MUST be ignored.
-        green_mask: u32,
-        /// BlueMask (4 bytes): A 32-bit unsigned integer that defines the
-        /// color mask that specifies the blue component of each pixel. If the
-        /// Compression value in the BitmapInfoHeader object is not
-        /// BI_BITFIELDS, this value MUST be ignored.
-        blue_mask: u32,
-        /// AlphaMask (4 bytes): A 32-bit unsigned integer that defines the
-        /// color mask that specifies the alpha component of each pixel.
-        alpha_mask: u32,
-        /// ColorSpaceType (4 bytes): A 32-bit unsigned integer that defines
-        /// the color space of the DeviceIndependentBitmap Object. If this
-        /// value is LCS_CALIBRATED_RGB from the LogicalColorSpace Enumeration,
-        /// the color values in the DIB are calibrated RGB values, and the
-        /// endpoints and gamma values in this structure SHOULD be used to
-        /// translate the color values before they are passed to the device.
-        ///
-        /// See the LogColorSpace and LogColorSpace ObjectW objects for details
-        /// concerning a logical color space.
-        color_space_type: crate::parser::LogicalColorSpace,
-        /// Endpoints (36 bytes): A CIEXYZTriple Object that defines the CIE
-        /// chromaticity x, y, and z coordinates of the three colors that
-        /// correspond to the red, green, and blue endpoints for the logical
-        /// color space associated with the DIB. If the ColorSpaceType field
-        /// does not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        endpoints: crate::parser::CIEXYZTriple,
-        /// GammaRed (4 bytes): A 32-bit fixed point value that defines the
-        /// toned response curve for red. If the ColorSpaceType field does not
-        /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        gamma_red: u32,
-        /// GammaGreen (4 bytes): A 32-bit fixed point value that defines the
-        /// toned response curve for green. If the ColorSpaceType field does
-        /// not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        gamma_green: u32,
-        /// GammaBlue (4 bytes): A 32-bit fixed point value that defines the
-        /// toned response curve for blue. If the ColorSpaceType field does not
-        /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
-        ///
-        /// The gamma value format is an unsigned "8.8" fixed-point integer
-        /// that is then left-shifted by 8 bits. "8.8" means "8 integer bits
-        /// followed by 8 fraction bits": nnnnnnnnffffffff. Taking the shift
-        /// into account, the required format of the 32-bit DWORD is:
-        /// 00000000nnnnnnnnffffffff00000000.
-        gamma_blue: u32,
-        /// Intent (4 bytes): A 32-bit unsigned integer that defines the
-        /// rendering intent for the DIB. This MUST be a value defined in the
-        /// GamutMappingIntent Enumeration.
-        intent: crate::parser::GamutMappingIntent,
-        /// ProfileData (4 bytes): A 32-bit unsigned integer that defines the
-        /// offset, in bytes, from the beginning of this structure to the start
-        /// of the color profile data.
-        ///
-        /// If the color profile is embedded in the DIB, ProfileData is the
-        /// offset to the actual color profile; if the color profile is linked,
-        /// ProfileData is the offset to the null-terminated file name of the
-        /// color profile. This MUST NOT be a Unicode string, but MUST be
-        /// composed exclusively of characters from the Windows character set
-        /// (code page 1252).
-        ///
-        /// If the ColorSpaceType field in the BitmapV4Header does not specify
-        /// LCS_PROFILE_LINKED or LCS_PROFILE_EMBEDDED, the color profile data
-        /// SHOULD be ignored.
-        profile_data: u32,
-        /// ProfileSize (4 bytes): A 32-bit unsigned integer that defines the
-        /// size, in bytes, of embedded color profile data.
-        profile_size: u32,
-        /// Reserved (4 bytes): A 32-bit unsigned integer that is undefined and
-        /// SHOULD be ignored.
-        reserved: u32,
-    },
+    Core(BitmapInfoHeaderCore),
+    Info(BitmapInfoHeaderInfo),
+    V4(BitmapInfoHeaderV4),
+    V5(BitmapInfoHeaderV5),
 }
 
 impl BitmapInfoHeader {
@@ -420,28 +22,30 @@ impl BitmapInfoHeader {
 
         match header_size {
             0x0000000C => {
-                let (header, c) = Self::parse_as_core(buf, header_size)?;
+                let (header, c) =
+                    BitmapInfoHeaderCore::parse(buf, header_size)?;
                 consumed_bytes += c;
 
-                Ok((header, consumed_bytes))
+                Ok((Self::Core(header), consumed_bytes))
             }
             13..=40 => {
-                let (header, c) = Self::parse_as_info(buf, header_size)?;
+                let (header, c) =
+                    BitmapInfoHeaderInfo::parse(buf, header_size)?;
                 consumed_bytes += c;
 
-                Ok((header, consumed_bytes))
+                Ok((Self::Info(header), consumed_bytes))
             }
             41..=108 => {
-                let (header, c) = Self::parse_as_v4(buf, header_size)?;
+                let (header, c) = BitmapInfoHeaderV4::parse(buf, header_size)?;
                 consumed_bytes += c;
 
-                Ok((header, consumed_bytes))
+                Ok((Self::V4(header), consumed_bytes))
             }
             109..=124 => {
-                let (header, c) = Self::parse_as_v5(buf, header_size)?;
+                let (header, c) = BitmapInfoHeaderV5::parse(buf, header_size)?;
                 consumed_bytes += c;
 
-                Ok((header, consumed_bytes))
+                Ok((Self::V5(header), consumed_bytes))
             }
             _ => Err(crate::parser::ParseError::UnexpectedPattern {
                 cause: format!(
@@ -454,29 +58,35 @@ impl BitmapInfoHeader {
 
     pub fn header_size(&self) -> u32 {
         match self {
-            Self::Core { header_size, .. }
-            | Self::Info { header_size, .. }
-            | Self::V4 { header_size, .. }
-            | Self::V5 { header_size, .. } => *header_size,
+            Self::Core(BitmapInfoHeaderCore { header_size, .. })
+            | Self::Info(BitmapInfoHeaderInfo { header_size, .. })
+            | Self::V4(BitmapInfoHeaderV4 { header_size, .. })
+            | Self::V5(BitmapInfoHeaderV5 { header_size, .. }) => *header_size,
         }
     }
 
     pub fn bit_count(&self) -> crate::parser::BitCount {
         match self {
-            Self::Core { bit_count, .. }
-            | Self::Info { bit_count, .. }
-            | Self::V4 { bit_count, .. }
-            | Self::V5 { bit_count, .. } => *bit_count,
+            Self::Core(BitmapInfoHeaderCore { bit_count, .. })
+            | Self::Info(BitmapInfoHeaderInfo { bit_count, .. })
+            | Self::V4(BitmapInfoHeaderV4 { bit_count, .. })
+            | Self::V5(BitmapInfoHeaderV5 { bit_count, .. }) => *bit_count,
         }
     }
 
     pub fn size(&self) -> usize {
         let size = match self {
-            Self::Core { width, height, planes, bit_count, .. } => u32::from(
+            Self::Core(BitmapInfoHeaderCore {
+                width,
+                height,
+                planes,
+                bit_count,
+                ..
+            }) => u32::from(
                 (((width * planes * (*bit_count as u16) + 31) & !31) / 8)
                     * height,
             ),
-            Self::Info {
+            Self::Info(BitmapInfoHeaderInfo {
                 width,
                 height,
                 planes,
@@ -484,8 +94,8 @@ impl BitmapInfoHeader {
                 image_size,
                 compression,
                 ..
-            }
-            | Self::V4 {
+            })
+            | Self::V4(BitmapInfoHeaderV4 {
                 width,
                 height,
                 planes,
@@ -493,8 +103,8 @@ impl BitmapInfoHeader {
                 image_size,
                 compression,
                 ..
-            }
-            | Self::V5 {
+            })
+            | Self::V5(BitmapInfoHeaderV5 {
                 width,
                 height,
                 planes,
@@ -502,7 +112,7 @@ impl BitmapInfoHeader {
                 image_size,
                 compression,
                 ..
-            } => match compression {
+            }) => match compression {
                 crate::parser::Compression::BI_RGB
                 | crate::parser::Compression::BI_BITFIELDS
                 | crate::parser::Compression::BI_CMYK => {
@@ -523,10 +133,14 @@ impl BitmapInfoHeader {
 
     pub fn color_used(&self) -> u32 {
         match self {
-            Self::Core { bit_count, .. } => 2u32.pow(*bit_count as u32),
-            Self::Info { bit_count, color_used, .. }
-            | Self::V4 { bit_count, color_used, .. }
-            | Self::V5 { bit_count, color_used, .. } => {
+            Self::Core(BitmapInfoHeaderCore { bit_count, .. }) => {
+                2u32.pow(*bit_count as u32)
+            }
+            Self::Info(BitmapInfoHeaderInfo {
+                bit_count, color_used, ..
+            })
+            | Self::V4(BitmapInfoHeaderV4 { bit_count, color_used, .. })
+            | Self::V5(BitmapInfoHeaderV5 { bit_count, color_used, .. }) => {
                 if *color_used == 0
                     && matches!(
                         bit_count,
@@ -545,19 +159,23 @@ impl BitmapInfoHeader {
 
     pub fn height(&self) -> usize {
         match self {
-            Self::Core { height, .. } => usize::from(*height),
-            Self::Info { height, .. }
-            | Self::V4 { height, .. }
-            | Self::V5 { height, .. } => *height as usize,
+            Self::Core(BitmapInfoHeaderCore { height, .. }) => {
+                usize::from(*height)
+            }
+            Self::Info(BitmapInfoHeaderInfo { height, .. })
+            | Self::V4(BitmapInfoHeaderV4 { height, .. })
+            | Self::V5(BitmapInfoHeaderV5 { height, .. }) => *height as usize,
         }
     }
 
     pub fn width(&self) -> usize {
         match self {
-            Self::Core { width, .. } => usize::from(*width),
-            Self::Info { width, .. }
-            | Self::V4 { width, .. }
-            | Self::V5 { width, .. } => *width as usize,
+            Self::Core(BitmapInfoHeaderCore { width, .. }) => {
+                usize::from(*width)
+            }
+            Self::Info(BitmapInfoHeaderInfo { width, .. })
+            | Self::V4(BitmapInfoHeaderV4 { width, .. })
+            | Self::V5(BitmapInfoHeaderV5 { width, .. }) => *width as usize,
         }
     }
 }

--- a/core/src/parser/objects/structure/bitmap_info_header/v4.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/v4.rs
@@ -1,18 +1,156 @@
-impl crate::parser::BitmapInfoHeader {
+/// The BitmapV4Header Object contains information about the dimensions and
+/// color format of a device-independent bitmap (DIB). It is an extension
+/// of the BitmapInfoHeader Object. (Windows NT 3.1, Windows NT 3.5, and
+/// Windows NT 3.51: This structure is not supported.)
+#[derive(Clone, Debug)]
+pub struct BitmapInfoHeaderV4 {
+    /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size of this object, in bytes.
+    pub header_size: u32,
+    /// Width (4 bytes): A 32-bit signed integer that defines the width of
+    /// the DIB, in pixels. This value MUST be positive.
+    ///
+    /// This field SHOULD specify the width of the decompressed image file,
+    /// if the Compression value specifies JPEG or PNG format. (Windows NT
+    /// 3.1, Windows NT 3.5, Windows NT 3.51, Windows 95, and Windows NT
+    /// 4.0: Neither JPEG nor PNG format is supported.)
+    pub width: i32,
+    /// Height (4 bytes): A 32-bit signed integer that defines the height
+    /// of the DIB, in pixels. This value MUST NOT be zero.
+    ///
+    /// | Value | Meaning |
+    /// |-|-|
+    /// | 0x00000000 < value | If this value is positive, the DIB is a bottom-up bitmap, and its origin is the lower-left corner. This field SHOULD specify the height of the decompressed image file, if the Compression value specifies JPEG or PNG format. |
+    /// | value < 0x00000000 | If this value is negative, the DIB is a top-down bitmap, and its origin is the upper-left corner. Top-down bitmaps do not support compression. |
+    pub height: i32,
+    /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
+    /// of planes for the target device. This value MUST be 0x0001.
+    pub planes: u16,
+    /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
+    /// number of bits that define each pixel and the maximum number of
+    /// colors in the DIB. This value MUST be in the BitCount Enumeration.
+    pub bit_count: crate::parser::BitCount,
+    /// Compression (4 bytes): A 32-bit unsigned integer that defines the
+    /// compression mode of the DIB. This value MUST be in the Compression
+    /// Enumeration.
+    ///
+    /// This value MUST NOT specify a compressed format if the DIB is a
+    /// top-down bitmap, as indicated by the Height value.
+    pub compression: crate::parser::Compression,
+    /// ImageSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size, in bytes, of the image.
+    ///
+    /// If the Compression value is BI_RGB, this value SHOULD be zero and
+    /// MUST be ignored. (Windows implementations might write a nonzero
+    /// value to this field, but it is ignored when the metafile is
+    /// parsed.)
+    ///
+    /// If the Compression value is BI_JPEG or BI_PNG, this value MUST
+    /// specify the size of the JPEG or PNG image buffer, respectively.
+    pub image_size: u32,
+    /// XPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
+    /// horizontal resolution, in pixels-per-meter, of the target device
+    /// for the DIB.
+    pub x_pels_per_meter: i32,
+    /// YPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
+    /// vertical resolution, in pixels-per-meter, of the target device for
+    /// the DIB.
+    pub y_pels_per_meter: i32,
+    /// ColorUsed (4 bytes): A 32-bit unsigned integer that specifies the
+    /// number of indexes in the color table used by the DIB, as follows:
+    ///
+    /// - If this value is zero, the DIB uses the maximum number of colors that
+    ///   correspond to the BitCount value.
+    /// - If this value is nonzero and the BitCount value is less than 16, this
+    ///   value specifies the number of colors used by the DIB.
+    /// - If this value is nonzero and the BitCount value is 16 or greater,
+    ///   this value specifies the size of the color table used to optimize
+    ///   performance of the system palette.
+    ///
+    /// Note If this value is nonzero and greater than the maximum possible
+    /// size of the color table based on the BitCount value, the maximum
+    /// color table size SHOULD be assumed.
+    pub color_used: u32,
+    /// ColorImportant (4 bytes): A 32-bit unsigned integer that defines
+    /// the number of color indexes that are required for displaying the
+    /// DIB. If this value is zero, all color indexes are required.
+    ///
+    /// A DIB is specified by a DeviceIndependentBitmap Object.
+    ///
+    /// When the array of pixels in the DIB immediately follows the
+    /// BitmapInfoHeader, the DIB is a packed bitmap. In a packed bitmap,
+    /// the ColorUsed value MUST be either 0x00000000 or the actual size of
+    /// the color table.
+    pub color_important: u32,
+    /// RedMask (4 bytes): A 32-bit unsigned integer that defines the color
+    /// mask that specifies the red component of each pixel. If the
+    /// Compression value in the BitmapInfoHeader object is not
+    /// BI_BITFIELDS, this value MUST be ignored.
+    pub red_mask: u32,
+    /// GreenMask (4 bytes): A 32-bit unsigned integer that defines the
+    /// color mask that specifies the green component of each pixel. If the
+    /// Compression value in the BitmapInfoHeader object is not
+    /// BI_BITFIELDS, this value MUST be ignored.
+    pub green_mask: u32,
+    /// BlueMask (4 bytes): A 32-bit unsigned integer that defines the
+    /// color mask that specifies the blue component of each pixel. If the
+    /// Compression value in the BitmapInfoHeader object is not
+    /// BI_BITFIELDS, this value MUST be ignored.
+    pub blue_mask: u32,
+    /// AlphaMask (4 bytes): A 32-bit unsigned integer that defines the
+    /// color mask that specifies the alpha component of each pixel.
+    pub alpha_mask: u32,
+    /// ColorSpaceType (4 bytes): A 32-bit unsigned integer that defines
+    /// the color space of the DeviceIndependentBitmap Object. If this
+    /// value is LCS_CALIBRATED_RGB from the LogicalColorSpace Enumeration,
+    /// the color values in the DIB are calibrated RGB values, and the
+    /// endpoints and gamma values in this structure SHOULD be used to
+    /// translate the color values before they are passed to the device.
+    ///
+    /// See the LogColorSpace and LogColorSpace ObjectW objects for details
+    /// concerning a logical color space.
+    pub color_space_type: crate::parser::LogicalColorSpace,
+    /// Endpoints (36 bytes): A CIEXYZTriple Object that defines the CIE
+    /// chromaticity x, y, and z coordinates of the three colors that
+    /// correspond to the red, green, and blue endpoints for the logical
+    /// color space associated with the DIB. If the ColorSpaceType field
+    /// does not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    pub endpoints: crate::parser::CIEXYZTriple,
+    /// GammaRed (4 bytes): A 32-bit fixed point value that defines the
+    /// toned response curve for red. If the ColorSpaceType field does not
+    /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    pub gamma_red: u32,
+    /// GammaGreen (4 bytes): A 32-bit fixed point value that defines the
+    /// toned response curve for green. If the ColorSpaceType field does
+    /// not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    pub gamma_green: u32,
+    /// GammaBlue (4 bytes): A 32-bit fixed point value that defines the
+    /// toned response curve for blue. If the ColorSpaceType field does not
+    /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    ///
+    /// The gamma value format is an unsigned "8.8" fixed-point integer
+    /// that is then left-shifted by 8 bits. "8.8" means "8 integer bits
+    /// followed by 8 fraction bits": nnnnnnnnffffffff. Taking the shift
+    /// into account, the required format of the 32-bit DWORD is:
+    /// 00000000nnnnnnnnffffffff00000000.
+    pub gamma_blue: u32,
+}
+
+impl BitmapInfoHeaderV4 {
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
         err(level = tracing::Level::ERROR, Display),
     ))]
-    pub fn parse_as_v4<R: crate::Read>(
+    pub(super) fn parse<R: crate::Read>(
         buf: &mut R,
         header_size: u32,
     ) -> Result<(Self, usize), crate::parser::ParseError> {
         let (
             (header, header_bytes),
-            (red_mask, red_mask_bytes),
-            (green_mask, green_mask_bytes),
-            (blue_mask, blue_mask_bytes),
+            (mut red_mask, red_mask_bytes),
+            (mut green_mask, green_mask_bytes),
+            (mut blue_mask, blue_mask_bytes),
             (alpha_mask, alpha_mask_bytes),
             (color_space_type, color_space_type_bytes),
             (endpoints, endpoints_bytes),
@@ -20,7 +158,7 @@ impl crate::parser::BitmapInfoHeader {
             (gamma_green, gamma_green_bytes),
             (gamma_blue, gamma_blue_bytes),
         ) = (
-            crate::parser::BitmapInfoHeader::parse_as_info(buf, header_size)?,
+            crate::parser::BitmapInfoHeaderInfo::parse(buf, header_size)?,
             crate::parser::read_u32_from_le_bytes(buf)?,
             crate::parser::read_u32_from_le_bytes(buf)?,
             crate::parser::read_u32_from_le_bytes(buf)?,
@@ -42,7 +180,7 @@ impl crate::parser::BitmapInfoHeader {
             + gamma_green_bytes
             + gamma_blue_bytes;
 
-        let Self::Info {
+        let crate::parser::BitmapInfoHeaderInfo {
             header_size,
             width,
             height,
@@ -54,13 +192,32 @@ impl crate::parser::BitmapInfoHeader {
             y_pels_per_meter,
             color_used,
             color_important,
-        } = header
-        else {
-            unreachable!()
-        };
+        } = header;
+
+        if matches!(
+            bit_count,
+            crate::parser::BitCount::BI_BITCOUNT_4
+                | crate::parser::BitCount::BI_BITCOUNT_6
+        ) && matches!(compression, crate::parser::Compression::BI_RGB)
+        {
+            // set default bit fields
+            match bit_count {
+                crate::parser::BitCount::BI_BITCOUNT_4 => {
+                    red_mask = 0x00007C00;
+                    green_mask = 0x000003E0;
+                    blue_mask = 0x0000001F;
+                }
+                crate::parser::BitCount::BI_BITCOUNT_6 => {
+                    red_mask = 0x00FF0000;
+                    green_mask = 0x0000FF00;
+                    blue_mask = 0x000000FF;
+                }
+                _ => {}
+            }
+        }
 
         Ok((
-            Self::V4 {
+            Self {
                 header_size,
                 width,
                 height,

--- a/core/src/parser/objects/structure/bitmap_info_header/v5.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/v5.rs
@@ -1,10 +1,174 @@
-impl crate::parser::BitmapInfoHeader {
+/// The BitmapV5Header Object contains information about the dimensions and
+/// color format of a device-independent bitmap (DIB). It is an extension
+/// of the BitmapV4Header Object. (Windows NT 3.1, Windows NT 3.5, Windows
+/// NT 3.51, Windows 95, and Windows NT 4.0: This structure is not
+/// supported.)
+#[derive(Clone, Debug)]
+pub struct BitmapInfoHeaderV5 {
+    /// HeaderSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size of this object, in bytes.
+    pub header_size: u32,
+    /// Width (4 bytes): A 32-bit signed integer that defines the width of
+    /// the DIB, in pixels. This value MUST be positive.
+    ///
+    /// This field SHOULD specify the width of the decompressed image file,
+    /// if the Compression value specifies JPEG or PNG format. (Windows NT
+    /// 3.1, Windows NT 3.5, Windows NT 3.51, Windows 95, and Windows NT
+    /// 4.0: Neither JPEG nor PNG format is supported.)
+    pub width: i32,
+    /// Height (4 bytes): A 32-bit signed integer that defines the height
+    /// of the DIB, in pixels. This value MUST NOT be zero.
+    ///
+    /// | Value | Meaning |
+    /// |-|-|
+    /// | 0x00000000 < value | If this value is positive, the DIB is a bottom-up bitmap, and its origin is the lower-left corner. This field SHOULD specify the height of the decompressed image file, if the Compression value specifies JPEG or PNG format. |
+    /// | value < 0x00000000 | If this value is negative, the DIB is a top-down bitmap, and its origin is the upper-left corner. Top-down bitmaps do not support compression. |
+    pub height: i32,
+    /// Planes (2 bytes): A 16-bit unsigned integer that defines the number
+    /// of planes for the target device. This value MUST be 0x0001.
+    pub planes: u16,
+    /// BitCount (2 bytes): A 16-bit unsigned integer that defines the
+    /// number of bits that define each pixel and the maximum number of
+    /// colors in the DIB. This value MUST be in the BitCount Enumeration.
+    pub bit_count: crate::parser::BitCount,
+    /// Compression (4 bytes): A 32-bit unsigned integer that defines the
+    /// compression mode of the DIB. This value MUST be in the Compression
+    /// Enumeration.
+    ///
+    /// This value MUST NOT specify a compressed format if the DIB is a
+    /// top-down bitmap, as indicated by the Height value.
+    pub compression: crate::parser::Compression,
+    /// ImageSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size, in bytes, of the image.
+    ///
+    /// If the Compression value is BI_RGB, this value SHOULD be zero and
+    /// MUST be ignored. (Windows implementations might write a nonzero
+    /// value to this field, but it is ignored when the metafile is
+    /// parsed.)
+    ///
+    /// If the Compression value is BI_JPEG or BI_PNG, this value MUST
+    /// specify the size of the JPEG or PNG image buffer, respectively.
+    pub image_size: u32,
+    /// XPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
+    /// horizontal resolution, in pixels-per-meter, of the target device
+    /// for the DIB.
+    pub x_pels_per_meter: i32,
+    /// YPelsPerMeter (4 bytes): A 32-bit signed integer that defines the
+    /// vertical resolution, in pixels-per-meter, of the target device for
+    /// the DIB.
+    pub y_pels_per_meter: i32,
+    /// ColorUsed (4 bytes): A 32-bit unsigned integer that specifies the
+    /// number of indexes in the color table used by the DIB, as follows:
+    ///
+    /// - If this value is zero, the DIB uses the maximum number of colors that
+    ///   correspond to the BitCount value.
+    /// - If this value is nonzero and the BitCount value is less than 16, this
+    ///   value specifies the number of colors used by the DIB.
+    /// - If this value is nonzero and the BitCount value is 16 or greater,
+    ///   this value specifies the size of the color table used to optimize
+    ///   performance of the system palette.
+    ///
+    /// Note If this value is nonzero and greater than the maximum possible
+    /// size of the color table based on the BitCount value, the maximum
+    /// color table size SHOULD be assumed.
+    pub color_used: u32,
+    /// ColorImportant (4 bytes): A 32-bit unsigned integer that defines
+    /// the number of color indexes that are required for displaying the
+    /// DIB. If this value is zero, all color indexes are required.
+    ///
+    /// A DIB is specified by a DeviceIndependentBitmap Object.
+    ///
+    /// When the array of pixels in the DIB immediately follows the
+    /// BitmapInfoHeader, the DIB is a packed bitmap. In a packed bitmap,
+    /// the ColorUsed value MUST be either 0x00000000 or the actual size of
+    /// the color table.
+    pub color_important: u32,
+    /// RedMask (4 bytes): A 32-bit unsigned integer that defines the color
+    /// mask that specifies the red component of each pixel. If the
+    /// Compression value in the BitmapInfoHeader object is not
+    /// BI_BITFIELDS, this value MUST be ignored.
+    pub red_mask: u32,
+    /// GreenMask (4 bytes): A 32-bit unsigned integer that defines the
+    /// color mask that specifies the green component of each pixel. If the
+    /// Compression value in the BitmapInfoHeader object is not
+    /// BI_BITFIELDS, this value MUST be ignored.
+    pub green_mask: u32,
+    /// BlueMask (4 bytes): A 32-bit unsigned integer that defines the
+    /// color mask that specifies the blue component of each pixel. If the
+    /// Compression value in the BitmapInfoHeader object is not
+    /// BI_BITFIELDS, this value MUST be ignored.
+    pub blue_mask: u32,
+    /// AlphaMask (4 bytes): A 32-bit unsigned integer that defines the
+    /// color mask that specifies the alpha component of each pixel.
+    pub alpha_mask: u32,
+    /// ColorSpaceType (4 bytes): A 32-bit unsigned integer that defines
+    /// the color space of the DeviceIndependentBitmap Object. If this
+    /// value is LCS_CALIBRATED_RGB from the LogicalColorSpace Enumeration,
+    /// the color values in the DIB are calibrated RGB values, and the
+    /// endpoints and gamma values in this structure SHOULD be used to
+    /// translate the color values before they are passed to the device.
+    ///
+    /// See the LogColorSpace and LogColorSpace ObjectW objects for details
+    /// concerning a logical color space.
+    pub color_space_type: crate::parser::LogicalColorSpace,
+    /// Endpoints (36 bytes): A CIEXYZTriple Object that defines the CIE
+    /// chromaticity x, y, and z coordinates of the three colors that
+    /// correspond to the red, green, and blue endpoints for the logical
+    /// color space associated with the DIB. If the ColorSpaceType field
+    /// does not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    pub endpoints: crate::parser::CIEXYZTriple,
+    /// GammaRed (4 bytes): A 32-bit fixed point value that defines the
+    /// toned response curve for red. If the ColorSpaceType field does not
+    /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    pub gamma_red: u32,
+    /// GammaGreen (4 bytes): A 32-bit fixed point value that defines the
+    /// toned response curve for green. If the ColorSpaceType field does
+    /// not specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    pub gamma_green: u32,
+    /// GammaBlue (4 bytes): A 32-bit fixed point value that defines the
+    /// toned response curve for blue. If the ColorSpaceType field does not
+    /// specify LCS_CALIBRATED_RGB, this field MUST be ignored.
+    ///
+    /// The gamma value format is an unsigned "8.8" fixed-point integer
+    /// that is then left-shifted by 8 bits. "8.8" means "8 integer bits
+    /// followed by 8 fraction bits": nnnnnnnnffffffff. Taking the shift
+    /// into account, the required format of the 32-bit DWORD is:
+    /// 00000000nnnnnnnnffffffff00000000.
+    pub gamma_blue: u32,
+    /// Intent (4 bytes): A 32-bit unsigned integer that defines the
+    /// rendering intent for the DIB. This MUST be a value defined in the
+    /// GamutMappingIntent Enumeration.
+    pub intent: crate::parser::GamutMappingIntent,
+    /// ProfileData (4 bytes): A 32-bit unsigned integer that defines the
+    /// offset, in bytes, from the beginning of this structure to the start
+    /// of the color profile data.
+    ///
+    /// If the color profile is embedded in the DIB, ProfileData is the
+    /// offset to the actual color profile; if the color profile is linked,
+    /// ProfileData is the offset to the null-terminated file name of the
+    /// color profile. This MUST NOT be a Unicode string, but MUST be
+    /// composed exclusively of characters from the Windows character set
+    /// (code page 1252).
+    ///
+    /// If the ColorSpaceType field in the BitmapV4Header does not specify
+    /// LCS_PROFILE_LINKED or LCS_PROFILE_EMBEDDED, the color profile data
+    /// SHOULD be ignored.
+    pub profile_data: u32,
+    /// ProfileSize (4 bytes): A 32-bit unsigned integer that defines the
+    /// size, in bytes, of embedded color profile data.
+    pub profile_size: u32,
+    /// Reserved (4 bytes): A 32-bit unsigned integer that is undefined and
+    /// SHOULD be ignored.
+    pub reserved: u32,
+}
+
+impl BitmapInfoHeaderV5 {
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = tracing::Level::TRACE,
         skip_all,
         err(level = tracing::Level::ERROR, Display),
     ))]
-    pub fn parse_as_v5<R: crate::Read>(
+    pub fn parse<R: crate::Read>(
         buf: &mut R,
         header_size: u32,
     ) -> Result<(Self, usize), crate::parser::ParseError> {
@@ -15,7 +179,7 @@ impl crate::parser::BitmapInfoHeader {
             (profile_size, profile_size_bytes),
             (reserved, reserved_bytes),
         ) = (
-            crate::parser::BitmapInfoHeader::parse_as_v4(buf, header_size)?,
+            crate::parser::BitmapInfoHeaderV4::parse(buf, header_size)?,
             crate::parser::GamutMappingIntent::parse(buf)?,
             crate::parser::read_u32_from_le_bytes(buf)?,
             crate::parser::read_u32_from_le_bytes(buf)?,
@@ -27,7 +191,7 @@ impl crate::parser::BitmapInfoHeader {
             + header_bytes
             + intent_bytes;
 
-        let Self::V4 {
+        let crate::parser::BitmapInfoHeaderV4 {
             header_size,
             width,
             height,
@@ -39,22 +203,41 @@ impl crate::parser::BitmapInfoHeader {
             y_pels_per_meter,
             color_used,
             color_important,
-            red_mask,
-            green_mask,
-            blue_mask,
+            mut red_mask,
+            mut green_mask,
+            mut blue_mask,
             alpha_mask,
             color_space_type,
             endpoints,
             gamma_red,
             gamma_green,
             gamma_blue,
-        } = header
-        else {
-            unreachable!()
-        };
+        } = header;
+
+        if matches!(
+            bit_count,
+            crate::parser::BitCount::BI_BITCOUNT_4
+                | crate::parser::BitCount::BI_BITCOUNT_6
+        ) && matches!(compression, crate::parser::Compression::BI_RGB)
+        {
+            // set default bit fields
+            match bit_count {
+                crate::parser::BitCount::BI_BITCOUNT_4 => {
+                    red_mask = 0x00007C00;
+                    green_mask = 0x000003E0;
+                    blue_mask = 0x0000001F;
+                }
+                crate::parser::BitCount::BI_BITCOUNT_6 => {
+                    red_mask = 0x00FF0000;
+                    green_mask = 0x0000FF00;
+                    blue_mask = 0x000000FF;
+                }
+                _ => {}
+            }
+        }
 
         Ok((
-            Self::V5 {
+            Self {
                 header_size,
                 width,
                 height,

--- a/core/src/parser/objects/structure/device_independent_bitmap.rs
+++ b/core/src/parser/objects/structure/device_independent_bitmap.rs
@@ -133,6 +133,7 @@ impl Colors {
         ));
 
         match dib_header_info.bit_count() {
+            crate::parser::BitCount::BI_BITCOUNT_0 => unreachable!(),
             crate::parser::BitCount::BI_BITCOUNT_1
             | crate::parser::BitCount::BI_BITCOUNT_2
             | crate::parser::BitCount::BI_BITCOUNT_3 => {
@@ -158,6 +159,7 @@ impl Colors {
             crate::parser::BitCount::BI_BITCOUNT_4
             | crate::parser::BitCount::BI_BITCOUNT_6 => {
                 match &dib_header_info {
+                    crate::parser::BitmapInfoHeader::Core(_) => unreachable!(),
                     crate::parser::BitmapInfoHeader::Info(
                         crate::parser::BitmapInfoHeaderInfo {
                             compression, ..
@@ -194,10 +196,8 @@ impl Colors {
                         }
                         _ => Ok((Colors::Null, 0)),
                     },
-                    _ => unreachable!(),
                 }
             }
-            _ => unreachable!(),
         }
     }
 
@@ -246,7 +246,7 @@ impl Colors {
 
                 Ok((Colors::PaletteIndices(table), consumed_bytes))
             }
-            _ => unreachable!(),
+            crate::parser::ColorUsage::DIB_PAL_INDICES => unreachable!(),
         }
     }
 }

--- a/core/src/parser/objects/structure/mod.rs
+++ b/core/src/parser/objects/structure/mod.rs
@@ -18,6 +18,7 @@ mod poly_polygon;
 mod rect;
 mod rect_l;
 mod rgb_quad;
+mod rgb_triple;
 mod scan;
 mod size_l;
 
@@ -26,7 +27,7 @@ pub use self::{
     color_ref::*, device_independent_bitmap::*, log_brush::*,
     log_color_space::*, log_color_space_w::*, palette_entry::*,
     pitch_and_family::*, point_l::*, point_s::*, poly_polygon::*, rect::*,
-    rect_l::*, rgb_quad::*, scan::*, size_l::*,
+    rect_l::*, rgb_quad::*, rgb_triple::*, scan::*, size_l::*,
 };
 use crate::imports::*;
 

--- a/core/src/parser/objects/structure/rgb_triple.rs
+++ b/core/src/parser/objects/structure/rgb_triple.rs
@@ -1,0 +1,33 @@
+/// The RGBTriple Object defines the pixel color values in an uncompressed DIB
+/// Object.
+#[derive(Clone, Debug)]
+pub struct RGBTriple {
+    /// Red (1 byte): An 8-bit unsigned integer that defines the relative
+    /// intensity of red.
+    pub red: u8,
+    /// Green (1 byte): An 8-bit unsigned integer that defines the relative
+    /// intensity of green.
+    pub green: u8,
+    /// Blue (1 byte): An 8-bit unsigned integer that defines the relative
+    /// intensity of blue.
+    pub blue: u8,
+}
+
+impl RGBTriple {
+    #[cfg_attr(feature = "tracing", tracing::instrument(
+        level = tracing::Level::TRACE,
+        skip_all,
+        err(level = tracing::Level::ERROR, Display),
+    ))]
+    pub fn parse<R: crate::Read>(
+        buf: &mut R,
+    ) -> Result<(Self, usize), crate::parser::ParseError> {
+        let ((red, red_bytes), (green, green_bytes), (blue, blue_bytes)) = (
+            crate::parser::read_u8_from_le_bytes(buf)?,
+            crate::parser::read_u8_from_le_bytes(buf)?,
+            crate::parser::read_u8_from_le_bytes(buf)?,
+        );
+
+        Ok((Self { red, green, blue }, red_bytes + green_bytes + blue_bytes))
+    }
+}

--- a/core/src/parser/records/object/dib_create_pattern_brush.rs
+++ b/core/src/parser/records/object/dib_create_pattern_brush.rs
@@ -50,7 +50,7 @@ impl META_DIBCREATEPATTERNBRUSH {
             crate::parser::RecordType::META_DIBCREATEPATTERNBRUSH,
         )?;
 
-        let ((style, style_bytes), (mut color_usage, color_usage_bytes)) = (
+        let ((mut style, style_bytes), (mut color_usage, color_usage_bytes)) = (
             crate::parser::BrushStyle::parse(buf)?,
             crate::parser::ColorUsage::parse(buf)?,
         );
@@ -58,6 +58,8 @@ impl META_DIBCREATEPATTERNBRUSH {
 
         if matches!(style, crate::parser::BrushStyle::BS_PATTERN) {
             color_usage = crate::parser::ColorUsage::DIB_RGB_COLORS;
+        } else {
+            style = crate::parser::BrushStyle::BS_DIBPATTERNPT;
         }
 
         let (target, c) =
@@ -78,43 +80,51 @@ impl META_DIBCREATEPATTERNBRUSH {
                 let dib = self.target.clone();
                 let (width, height, planes, bits_pixel) =
                     match dib.dib_header_info {
-                        crate::parser::BitmapInfoHeader::Core {
-                            width,
-                            height,
-                            planes,
-                            bit_count,
-                            ..
-                        } => (
+                        crate::parser::BitmapInfoHeader::Core(
+                            crate::parser::BitmapInfoHeaderCore {
+                                width,
+                                height,
+                                planes,
+                                bit_count,
+                                ..
+                            },
+                        ) => (
                             i16::try_from(width).expect("should be as i16"),
                             i16::try_from(height).expect("should be as i16"),
                             u8::try_from(planes).expect("should be as u8"),
-                            bit_count as u8,
+                            bit_count,
                         ),
-                        crate::parser::BitmapInfoHeader::Info {
-                            width,
-                            height,
-                            planes,
-                            bit_count,
-                            ..
-                        }
-                        | crate::parser::BitmapInfoHeader::V4 {
-                            width,
-                            height,
-                            planes,
-                            bit_count,
-                            ..
-                        }
-                        | crate::parser::BitmapInfoHeader::V5 {
-                            width,
-                            height,
-                            planes,
-                            bit_count,
-                            ..
-                        } => (
+                        crate::parser::BitmapInfoHeader::Info(
+                            crate::parser::BitmapInfoHeaderInfo {
+                                width,
+                                height,
+                                planes,
+                                bit_count,
+                                ..
+                            },
+                        )
+                        | crate::parser::BitmapInfoHeader::V4(
+                            crate::parser::BitmapInfoHeaderV4 {
+                                width,
+                                height,
+                                planes,
+                                bit_count,
+                                ..
+                            },
+                        )
+                        | crate::parser::BitmapInfoHeader::V5(
+                            crate::parser::BitmapInfoHeaderV5 {
+                                width,
+                                height,
+                                planes,
+                                bit_count,
+                                ..
+                            },
+                        ) => (
                             i16::try_from(width).expect("should be i16"),
                             i16::try_from(height).expect("should be i16"),
                             u8::try_from(planes).expect("should be as u8"),
-                            bit_count as u8,
+                            bit_count,
                         ),
                     };
 


### PR DESCRIPTION
## Abstract

- Extract color data from bitmap color palette.
  - Chrome cannot show Bitmap using color palette.
- update dependencies.
