### PR TITLE
fix: incorrect text position with TA_UPDATECP

### DIFF
--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -766,22 +766,29 @@ impl crate::converter::Player for SVGPlayer {
         let font_height = self.selected_font()?.height;
         let point = {
             let point = PointS {
-                x: record.x,
-                y: record.y
-                    + (if matches!(
-                        self.context_current.text_align_vertical,
-                        VerticalTextAlignmentMode::VTA_BASELINE
-                            | VerticalTextAlignmentMode::VTA_BOTTOM
-                    ) && font_height < 0
-                    {
-                        -font_height
-                    } else {
-                        0
-                    }),
+                x: if self.context_current.text_align_update_cp {
+                    self.context_current.drawing_position.x
+                } else {
+                    record.x
+                },
+                y: if self.context_current.text_align_update_cp {
+                    self.context_current.drawing_position.y
+                } else {
+                    record.y
+                } + (if matches!(
+                    self.context_current.text_align_vertical,
+                    VerticalTextAlignmentMode::VTA_BASELINE
+                        | VerticalTextAlignmentMode::VTA_BOTTOM
+                ) && font_height < 0
+                {
+                    -font_height
+                } else {
+                    0
+                }),
             };
 
             let point = if self.context_current.text_align_update_cp {
-                self.context_current.point_s_to_relative_point(&point)
+                point
             } else {
                 self.context_current.point_s_to_absolute_point(&point)
             };


### PR DESCRIPTION
Hello. This product is so nice!

I have a problem. Texts in a wmf file that is exported from ChemDraw is not properly rendered.

The file is attached below.
[aniline_black.wmf.zip](https://github.com/user-attachments/files/20959945/aniline_black.wmf.zip)

The expected result is 
![aniline_black](https://github.com/user-attachments/assets/8741230f-9545-4a97-8ba9-2d9e45827c49)



TA_UPDATECB should use only drawing position without record position. In the Microsoft's documentation, it is written that "The drawing position in the playback device context MUST be updated after each text output call. It MUST be used as the reference point." in TA_UPDATECP.