### PR TITLE
fix: incorrect svg size

### DIFF
--- a/core/src/converter/svg/device_context.rs
+++ b/core/src/converter/svg/device_context.rs
@@ -238,11 +238,6 @@ impl Window {
     }
 
     pub fn origin(mut self, origin_x: i16, origin_y: i16) -> Self {
-        let x = self.x - self.origin_x + origin_x;
-        let y = self.y - self.origin_y + origin_y;
-
-        self.x = x;
-        self.y = y;
         self.origin_x = origin_x;
         self.origin_y = origin_y;
         self


### PR DESCRIPTION
When set window origin, it should not change x and y.
This causes a problem that the exported SVG has bigger screen size.

This file is exported from ChemDraw.
[test.wmf.zip](https://github.com/user-attachments/files/20960173/test.wmf.zip)

The initial record is this
```
2025-06-28T10:32:45.224413Z DEBUG wmf_core::converter: core/src/converter/mod.rs:63: record_number=0 header=StartsWithPlaceable(META_PLACEABLE { key: 2596720087, hwmf: 0, bounding_box: Rect { left: 2112, top: 2924, right: 2749, bottom: 4176 }, inch: 720, reserved: 0, checksum: [0, 76] }, META_HEADER { typ: MEMORYMETAFILE, header_size: 9, version: METAVERSION300, size_low: 2314, size_high: 0, number_of_objects: 8, max_record: 888, number_of_members: 0 })
2025-06-28T10:32:45.224595Z DEBUG wmf_core::converter: core/src/converter/mod.rs:650: record_number=1 record=META_SETMAPMODE { record_size: RecordSize(size: 0x00000004, consumed_bytes: 8), record_function: 259, map_mode: MM_ANISOTROPIC }
2025-06-28T10:32:45.224657Z DEBUG wmf_core::converter: core/src/converter/mod.rs:782: record_number=2 record=META_SETWINDOWEXT { record_size: RecordSize(size: 0x00000005, consumed_bytes: 10), record_function: 524, y: 1252, x: 637 }
2025-06-28T10:32:45.224694Z DEBUG wmf_core::converter: core/src/converter/mod.rs:792: record_number=3 record=META_SETWINDOWORG { record_size: RecordSize(size: 0x00000005, consumed_bytes: 10), record_function: 523, y: 2924, x: 2112 }
```
