### PR TITLE
Fix wrong arc command

### DIFF
--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -562,8 +562,8 @@ impl crate::converter::Player for SVGPlayer {
         let end_dx = i32::from(end.x - center.x);
         let end_dy = i32::from(end.y - center.y);
 
-        // Calculate cross product to determine the quadrant of the arc
-        // Invert the sign because upper-left is origin.
+        // Calculate cross product to determine if the arc is larger than 180
+        // degrees. Invert the sign because upper-left is origin.
         let cross = -(start_dx * end_dy - start_dy * end_dx);
         // If the arc is less than 180 degrees (equivalent to the cross product
         // is positive), it is not the larger arc.

--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -557,18 +557,17 @@ impl crate::converter::Player for SVGPlayer {
             y: record.top_rect + ry,
         });
         // Start and end vectors relative to the center of the ellipse
-        let start_dx = i32::from(start.x - center.x);
-        let start_dy = i32::from(start.y - center.y);
-        let end_dx = i32::from(end.x - center.x);
-        let end_dy = i32::from(end.y - center.y);
+        let start_dx = f32::from(start.x - center.x);
+        let start_dy = f32::from(start.y - center.y);
+        let end_dx = f32::from(end.x - center.x);
+        let end_dy = f32::from(end.y - center.y);
 
         // Calculate cross product to determine if the arc is larger than 180
         // degrees. Invert the sign because upper-left is origin.
-        let cross = -(start_dx.checked_mul(end_dy).unwrap_or(i32::MAX)
-            - start_dy.checked_mul(end_dx).unwrap_or(i32::MAX));
+        let cross = -(start_dx * end_dy - start_dy * end_dx);
         // If the arc is less than 180 degrees (equivalent to the cross product
         // is positive), it is not the larger arc.
-        let large_arc = i16::from(cross < 0);
+        let large_arc = i16::from(cross < 0.0);
 
         // sweep is always 0 ( equivalent to "counter-clockwise" in SVG )
         let data = Data::new()

--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -556,105 +556,25 @@ impl crate::converter::Player for SVGPlayer {
             x: record.left_rect + rx,
             y: record.top_rect + ry,
         });
+        // Normalize the start and end points to the ellipse's center
+        let start_dx = f32::from(start.x - center.x) / f32::from(rx);
+        let start_dy = f32::from(start.y - center.y) / f32::from(ry);
+        let end_dx = f32::from(end.x - center.x) / f32::from(rx);
+        let end_dy = f32::from(end.y - center.y) / f32::from(ry);
 
-        let center_x = if center.x < start.x && center.x < end.x {
-            "left"
-        } else if start.x < center.x && end.x < center.x {
-            "right"
-        } else {
-            "middle"
-        };
-        let center_y = if start.y < center.y && end.y < center.y {
-            "over"
-        } else if center.y < start.y && center.y < end.y {
-            "under"
-        } else {
-            "middle"
-        };
-        // if center_x or center_y is middle,
-        // fix sweep as negative-angle direction.
-        #[allow(clippy::match_same_arms)]
-        let (large_arc, sweep) = match (center_x, center_y) {
-            ("left", "over") if start.x < end.x && start.y > end.y => (0, 0),
-            ("left", "over") if start.x > end.x && start.y < end.y => (0, 1),
-            ("left", "middle") if start.x < end.x && start.y < end.y => (1, 0),
-            ("left", "middle") if start.x < end.x && start.y > end.y => (0, 0),
-            ("left", "middle") if start.x > end.x && start.y < end.y => (1, 0),
-            ("left", "middle") if start.x > end.x && start.y > end.y => (0, 0),
-            ("left", "under") if start.x < end.x && start.y < end.y => (0, 1),
-            ("left", "under") if start.x > end.x && start.y > end.y => (0, 0),
-            ("right", "over") if start.x < end.x && start.y < end.y => (0, 0),
-            ("right", "over") if start.x > end.x && start.y > end.y => (0, 1),
-            ("right", "middle") if start.x < end.x && start.y < end.y => (0, 0),
-            ("right", "middle") if start.x < end.x && start.y > end.y => (1, 0),
-            ("right", "middle") if start.x > end.x && start.y < end.y => (0, 0),
-            ("right", "middle") if start.x > end.x && start.y > end.y => (1, 0),
-            ("right", "under") if start.x < end.x && start.y > end.y => (0, 1),
-            ("right", "under") if start.x > end.x && start.y < end.y => (0, 0),
-            ("middle", "over") if start.x < end.x && start.y < end.y => (0, 0),
-            ("middle", "over") if start.x > end.x && start.y > end.y => (1, 0),
-            ("middle", "under") if start.x < end.x && start.y < end.y => (1, 0),
-            ("middle", "under") if start.x > end.x && start.y > end.y => (0, 0),
-            ("middle", "middle") if start.x <= end.x && start.y <= end.y => {
-                let antipodal = PointS {
-                    x: start.x + (center.x - start.x) * 2,
-                    y: start.y + (center.y - start.y) * 2,
-                };
+        // Calculate cross product to determine the quadrant of the arc
+        // Invert the sign because upper-left is origin.
+        let cross = -(start_dx * end_dy - start_dy * end_dx);
+        // If the arc is less than 180 degrees (equivalent to the cross product
+        // is positive), it is not the larger arc.
+        let large_arc = i32::from(cross < 0.0);
 
-                if antipodal.x < end.x {
-                    (1, 0)
-                } else {
-                    (0, 0)
-                }
-            }
-            ("middle", "middle") if start.x <= end.x && start.y >= end.y => {
-                let antipodal = PointS {
-                    x: start.x + (center.x - start.x) * 2,
-                    y: start.y + (center.y - start.y) * 2,
-                };
-
-                if antipodal.x < end.x {
-                    (0, 0)
-                } else {
-                    (1, 0)
-                }
-            }
-            ("middle", "middle") if start.x >= end.x && start.y <= end.y => {
-                let antipodal = PointS {
-                    x: start.x - (center.x - end.x) * 2,
-                    y: start.y - (center.y - end.y) * 2,
-                };
-
-                if antipodal.x < end.x {
-                    (1, 0)
-                } else {
-                    (0, 0)
-                }
-            }
-            ("middle", "middle") if start.x >= end.x && start.y >= end.y => {
-                let antipodal = PointS {
-                    x: start.x - (center.x - end.x) * 2,
-                    y: start.y - (center.y - end.y) * 2,
-                };
-
-                if antipodal.x < end.x {
-                    (0, 0)
-                } else {
-                    (1, 0)
-                }
-            }
-            _ => {
-                return Err(PlayError::InvalidRecord {
-                    cause: "invalid points and bounding rectangle".to_owned(),
-                });
-            }
-        };
-
+        // sweep is always 0 ( equivalent to "counter-clockwise" in SVG )
         let data = Data::new()
             .move_to(format!("{} {}", start.x, start.y))
             .elliptical_arc_to(format!(
                 "{} {} {} {} {} {} {}",
-                rx, ry, 0, large_arc, sweep, end.x, end.y
+                rx, ry, 0, large_arc, 0, end.x, end.y
             ));
         let path =
             Node::new("path").set("fill", "none").set("d", data.to_string());

--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -564,7 +564,8 @@ impl crate::converter::Player for SVGPlayer {
 
         // Calculate cross product to determine if the arc is larger than 180
         // degrees. Invert the sign because upper-left is origin.
-        let cross = -(start_dx * end_dy - start_dy * end_dx);
+        let cross = -(start_dx.checked_mul(end_dy).unwrap_or(i32::MAX)
+            - start_dy.checked_mul(end_dx).unwrap_or(i32::MAX));
         // If the arc is less than 180 degrees (equivalent to the cross product
         // is positive), it is not the larger arc.
         let large_arc = i16::from(cross < 0);

--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -556,18 +556,18 @@ impl crate::converter::Player for SVGPlayer {
             x: record.left_rect + rx,
             y: record.top_rect + ry,
         });
-        // Normalize the start and end points to the ellipse's center
-        let start_dx = f32::from(start.x - center.x) / f32::from(rx);
-        let start_dy = f32::from(start.y - center.y) / f32::from(ry);
-        let end_dx = f32::from(end.x - center.x) / f32::from(rx);
-        let end_dy = f32::from(end.y - center.y) / f32::from(ry);
+        // Start and end vectors relative to the center of the ellipse
+        let start_dx = i32::from(start.x - center.x);
+        let start_dy = i32::from(start.y - center.y);
+        let end_dx = i32::from(end.x - center.x);
+        let end_dy = i32::from(end.y - center.y);
 
         // Calculate cross product to determine the quadrant of the arc
         // Invert the sign because upper-left is origin.
         let cross = -(start_dx * end_dy - start_dy * end_dx);
         // If the arc is less than 180 degrees (equivalent to the cross product
         // is positive), it is not the larger arc.
-        let large_arc = i32::from(cross < 0.0);
+        let large_arc = i16::from(cross < 0);
 
         // sweep is always 0 ( equivalent to "counter-clockwise" in SVG )
         let data = Data::new()

--- a/core/src/converter/svg/node.rs
+++ b/core/src/converter/svg/node.rs
@@ -114,7 +114,7 @@ impl Data {
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
     pub fn elliptical_arc_to(mut self, param: impl Into<Parameters>) -> Self {
-        self.commands.push(format!("L {}", param.into().0));
+        self.commands.push(format!("A {}", param.into().0));
         self
     }
 }


### PR DESCRIPTION
This PR, I fixed some problems with arc.

[arrows.wmf.zip](https://github.com/user-attachments/files/21022443/arrows.wmf.zip)

I tested with arrows.wmf.

- SVG arc command is wrong. I fixed the command.
- Some wmf files can't be converted because some patterns are not implemented.
- Some patterns return wrong parameters.
- So I changed the calculation of `large_arc` and `sweep` to more simple way.