### PR TITLE
refactor: converter.

### DIFF
--- a/core/src/converter/bitmap.rs
+++ b/core/src/converter/bitmap.rs
@@ -26,7 +26,6 @@ impl From<DeviceIndependentBitmap> for Bitmap {
         let dib = dib.expand_color_palette();
 
         let mut info_header = vec![];
-        let mut file_size: u32 = 0;
 
         // write info header
         match dib.dib_header_info {
@@ -37,7 +36,6 @@ impl From<DeviceIndependentBitmap> for Bitmap {
                 planes,
                 bit_count,
             }) => {
-                file_size += header_size;
                 info_header.extend(header_size.to_le_bytes());
                 info_header.extend(width.to_le_bytes());
                 info_header.extend(height.to_le_bytes());
@@ -57,7 +55,6 @@ impl From<DeviceIndependentBitmap> for Bitmap {
                 color_used,
                 color_important,
             }) => {
-                file_size += header_size;
                 info_header.extend(header_size.to_le_bytes());
                 info_header.extend(width.to_le_bytes());
                 info_header.extend(height.to_le_bytes());
@@ -92,7 +89,6 @@ impl From<DeviceIndependentBitmap> for Bitmap {
                 gamma_green,
                 gamma_blue,
             }) => {
-                file_size += header_size;
                 info_header.extend(header_size.to_le_bytes());
                 info_header.extend(width.to_le_bytes());
                 info_header.extend(height.to_le_bytes());
@@ -148,7 +144,6 @@ impl From<DeviceIndependentBitmap> for Bitmap {
                 profile_size,
                 reserved,
             }) => {
-                file_size += header_size;
                 info_header.extend(header_size.to_le_bytes());
                 info_header.extend(width.to_le_bytes());
                 info_header.extend(height.to_le_bytes());
@@ -186,16 +181,20 @@ impl From<DeviceIndependentBitmap> for Bitmap {
 
         // write pixel data
         let data = dib.bitmap_buffer.a_data;
-        let data_len = u32::try_from(data.len()).expect("should be as u32");
-        file_size += data_len;
 
-        // write file headers
+        // BMP file header (14 bytes) + info header + pixel data
+        let bmp_file_header_size: u32 = 14;
+        let info_header_len =
+            u32::try_from(info_header.len()).expect("should be as u32");
+        let data_len = u32::try_from(data.len()).expect("should be as u32");
+        let file_size = bmp_file_header_size + info_header_len + data_len;
+        let data_offset = bmp_file_header_size + info_header_len;
+
         let mut file_header = vec![];
-        file_size += 14;
         file_header.extend(b"BM");
         file_header.extend(file_size.to_le_bytes());
         file_header.extend(0u32.to_le_bytes());
-        file_header.extend((file_size - data_len).to_le_bytes());
+        file_header.extend(data_offset.to_le_bytes());
 
         let data = {
             file_header.extend(info_header);
@@ -314,15 +313,13 @@ impl DeviceIndependentBitmap {
 
         let Self { dib_header_info, colors, bitmap_buffer } = self;
         let bit_count = dib_header_info.bit_count();
-        let palette: Vec<_> = match colors {
-            Colors::RGBTriple(values) => values
-                .into_iter()
-                .map(|v| vec![v.red, v.green, v.blue])
-                .collect(),
-            Colors::RGBQuad(values) => values
-                .into_iter()
-                .map(|v| vec![v.red, v.green, v.blue])
-                .collect(),
+        let palette: Vec<[u8; 3]> = match colors {
+            Colors::RGBTriple(values) => {
+                values.into_iter().map(|v| [v.red, v.green, v.blue]).collect()
+            }
+            Colors::RGBQuad(values) => {
+                values.into_iter().map(|v| [v.red, v.green, v.blue]).collect()
+            }
             _ => unreachable!(),
         };
 
@@ -349,8 +346,8 @@ impl DeviceIndependentBitmap {
 
                 let rgb = palette
                     .get(idx as usize)
-                    .cloned()
-                    .unwrap_or_else(|| vec![0xFF, 0xFF, 0xFF]);
+                    .copied()
+                    .unwrap_or([0xFF, 0xFF, 0xFF]);
 
                 new_data.extend(rgb);
             }

--- a/core/src/converter/graphics_object.rs
+++ b/core/src/converter/graphics_object.rs
@@ -19,7 +19,15 @@ impl GraphicsObjects {
     }
 
     pub fn delete(&mut self, i: usize) {
-        self.0[i] = GraphicsObject::Null;
+        if let Some(slot) = self.0.get_mut(i) {
+            *slot = GraphicsObject::Null;
+        } else {
+            warn!(
+                index = i,
+                capacity = self.0.len(),
+                "object table index out of bounds on delete",
+            );
+        }
     }
 
     pub fn get(&self, i: usize) -> &GraphicsObject {
@@ -30,9 +38,11 @@ impl GraphicsObjects {
         for (i, v) in self.0.iter_mut().enumerate() {
             if matches!(&v, GraphicsObject::Null) {
                 self.0[i] = g;
-                break;
+                return;
             }
         }
+
+        warn!(capacity = self.0.len(), "object table is full, ignoring push");
     }
 }
 
@@ -86,28 +96,23 @@ impl Default for SelectedGraphicsObject {
 }
 
 impl SelectedGraphicsObject {
-    pub fn brush(mut self, brush: Brush) -> Self {
+    pub fn set_brush(&mut self, brush: Brush) {
         self.brush = brush;
-        self
     }
 
-    pub fn font(mut self, font: Font) -> Self {
+    pub fn set_font(&mut self, font: Font) {
         self.font = font;
-        self
     }
 
-    pub fn palette(mut self, palette: Palette) -> Self {
+    pub fn set_palette(&mut self, palette: Palette) {
         self.palette = palette.into();
-        self
     }
 
-    pub fn pen(mut self, pen: Pen) -> Self {
+    pub fn set_pen(&mut self, pen: Pen) {
         self.pen = pen;
-        self
     }
 
-    pub fn region(mut self, region: Region) -> Self {
+    pub fn set_region(&mut self, region: Region) {
         self.region = region.into();
-        self
     }
 }

--- a/core/src/converter/mod.rs
+++ b/core/src/converter/mod.rs
@@ -68,9 +68,11 @@ where
 
             let mut record_size = RecordSize::parse(buf)?;
             if record_size.byte_count() == 0 {
-                debug!(%record_size, "skip parsing zero-sized record");
-
-                continue;
+                return Err(ConvertError::ParseError {
+                    source: ParseError::UnexpectedPattern {
+                        cause: "record size is zero".to_owned(),
+                    },
+                });
             }
 
             let (record_function, c) =
@@ -791,6 +793,9 @@ where
                         read_variable(buf, record_size.remaining_bytes())
                             .map_err(ParseError::from)?;
 
+                    // META_ESCAPE contains vendor-specific data that
+                    // does not affect rendering. Parse failures are
+                    // logged but intentionally not propagated.
                     match META_ESCAPE::parse(
                         &mut buf.as_slice(),
                         record_size,

--- a/core/src/converter/player.rs
+++ b/core/src/converter/player.rs
@@ -205,7 +205,7 @@ pub trait Player: Sized {
         self,
         record_number: usize,
         record: META_TEXTOUT,
-    ) -> Result<Self, crate::converter::PlayError>;
+    ) -> Result<Self, PlayError>;
 
     // .
     // .
@@ -249,7 +249,7 @@ pub trait Player: Sized {
         self,
         record_number: usize,
         record: META_CREATEREGION,
-    ) -> Result<Self, crate::converter::PlayError>;
+    ) -> Result<Self, PlayError>;
     /// Render [`META_DELETEOBJECT`](crate::parser::META_DELETEOBJECT) record.
     fn delete_object(
         self,

--- a/core/src/converter/svg/device_context.rs
+++ b/core/src/converter/svg/device_context.rs
@@ -165,10 +165,12 @@ impl DeviceContext {
     }
 
     pub fn point_s_to_absolute_point(&self, point: &PointS) -> PointS {
-        let dx =
-            f32::from(point.x - self.window.origin_x) / self.window.scale_x;
-        let dy =
-            f32::from(point.y - self.window.origin_y) / self.window.scale_y;
+        // Widen to f32 before subtraction to avoid i16 overflow.
+        // i16 values fit in f32 without precision loss.
+        let dx = (f32::from(point.x) - f32::from(self.window.origin_x))
+            / self.window.scale_x;
+        let dy = (f32::from(point.y) - f32::from(self.window.origin_y))
+            / self.window.scale_y;
 
         // Negative extent means the axis is flipped
         let x = (if self.window.flip_x { -dx } else { dx }) as i16;
@@ -178,10 +180,12 @@ impl DeviceContext {
     }
 
     pub fn point_s_to_relative_point(&self, point: &PointS) -> PointS {
-        let dx =
-            f32::from(point.x - self.window.origin_x) / self.window.scale_x;
-        let dy =
-            f32::from(point.y - self.window.origin_y) / self.window.scale_y;
+        // Widen to f32 before subtraction to avoid i16 overflow.
+        // i16 values fit in f32 without precision loss.
+        let dx = (f32::from(point.x) - f32::from(self.window.origin_x))
+            / self.window.scale_x;
+        let dy = (f32::from(point.y) - f32::from(self.window.origin_y))
+            / self.window.scale_y;
 
         let x = (if self.window.flip_x { -dx } else { dx }) as i16
             + self.drawing_position.x;
@@ -223,8 +227,8 @@ pub struct Window {
 impl Default for Window {
     fn default() -> Self {
         Self {
-            x: 1024,
-            y: 1024,
+            x: 0,
+            y: 0,
             origin_x: 0,
             origin_y: 0,
             scale_x: 1.0,

--- a/core/src/converter/svg/device_context.rs
+++ b/core/src/converter/svg/device_context.rs
@@ -245,8 +245,10 @@ impl Window {
     pub fn ext(&mut self, x: i16, y: i16) {
         self.flip_x = x < 0;
         self.flip_y = y < 0;
-        self.x = x.abs();
-        self.y = y.abs();
+        self.x = i16::try_from(x.unsigned_abs())
+            .unwrap_or(i16::MAX);
+        self.y = i16::try_from(y.unsigned_abs())
+            .unwrap_or(i16::MAX);
     }
 
     pub fn origin(&mut self, origin_x: i16, origin_y: i16) {
@@ -259,11 +261,16 @@ impl Window {
         self.scale_y = scale_y;
     }
 
-    pub fn as_view_box(&self) -> (i16, i16, i16, i16) {
+    pub fn as_view_box(&self) -> (i32, i32, i32, i32) {
         // Expand viewBox to include negative coordinates if any
-        let min_x = self.min_x.min(0);
-        let min_y = self.min_y.min(0);
+        let min_x = i32::from(self.min_x).min(0);
+        let min_y = i32::from(self.min_y).min(0);
 
-        (min_x, min_y, self.x - min_x, self.y - min_y)
+        (
+            min_x,
+            min_y,
+            i32::from(self.x) - min_x,
+            i32::from(self.y) - min_y,
+        )
     }
 }

--- a/core/src/converter/svg/device_context.rs
+++ b/core/src/converter/svg/device_context.rs
@@ -245,10 +245,8 @@ impl Window {
     pub fn ext(&mut self, x: i16, y: i16) {
         self.flip_x = x < 0;
         self.flip_y = y < 0;
-        self.x = i16::try_from(x.unsigned_abs())
-            .unwrap_or(i16::MAX);
-        self.y = i16::try_from(y.unsigned_abs())
-            .unwrap_or(i16::MAX);
+        self.x = i16::try_from(x.unsigned_abs()).unwrap_or(i16::MAX);
+        self.y = i16::try_from(y.unsigned_abs()).unwrap_or(i16::MAX);
     }
 
     pub fn origin(&mut self, origin_x: i16, origin_y: i16) {
@@ -265,12 +263,9 @@ impl Window {
         // Expand viewBox to include negative coordinates if any
         let min_x = i32::from(self.min_x).min(0);
         let min_y = i32::from(self.min_y).min(0);
+        let max_x = i32::from(self.x);
+        let max_y = i32::from(self.y);
 
-        (
-            min_x,
-            min_y,
-            i32::from(self.x) - min_x,
-            i32::from(self.y) - min_y,
-        )
+        (min_x, min_y, max_x - min_x, max_y - min_y)
     }
 }

--- a/core/src/converter/svg/device_context.rs
+++ b/core/src/converter/svg/device_context.rs
@@ -45,113 +45,108 @@ impl Default for DeviceContext {
 
 // mutations
 impl DeviceContext {
-    pub fn bk_mode(mut self, bk_mode: MixMode) -> Self {
+    pub fn bk_mode(&mut self, bk_mode: MixMode) {
         self.bk_mode = bk_mode;
-        self
     }
 
-    pub fn create_object_table(mut self, length: u16) -> Self {
+    pub fn create_object_table(&mut self, length: u16) {
         self.object_table = GraphicsObjects::new(length as usize);
-        self
     }
 
-    pub fn clipping_region(mut self, clipping_region: Rect) -> Self {
-        let clipping_region = if let Some(ref existing) = self.clipping_region {
-            if let Some(overlap_region) = existing.overlap(&clipping_region) {
-                overlap_region
-            } else {
-                clipping_region
-            }
+    pub fn clipping_region(&mut self, clipping_region: Rect) {
+        self.clipping_region = if let Some(ref existing) = self.clipping_region
+        {
+            existing.overlap(&clipping_region).unwrap_or(clipping_region)
         } else {
             clipping_region
-        };
-
-        self.clipping_region = clipping_region.into();
-        self
+        }
+        .into();
     }
 
-    pub fn drawing_position(mut self, drawing_position: PointS) -> Self {
+    pub fn drawing_position(&mut self, drawing_position: PointS) {
         self.drawing_position = drawing_position;
-        self
     }
 
-    pub fn draw_mode(mut self, draw_mode: BinaryRasterOperation) -> Self {
+    pub fn draw_mode(&mut self, draw_mode: BinaryRasterOperation) {
         self.draw_mode = draw_mode.into();
-        self
     }
 
-    pub fn extend_window(self, p: &PointS) -> Self {
-        let (mut x, mut y) = (0, 0);
+    pub fn extend_window(&mut self, p: &PointS) {
+        // Track minimum coordinates for viewBox expansion
+        self.window.min_x = self.window.min_x.min(p.x);
+        self.window.min_y = self.window.min_y.min(p.y);
 
+        // Track maximum coordinates (extend x and y independently)
         if self.window.x < p.x {
-            x = p.x;
+            self.window.x = p.x;
         }
 
         if self.window.y < p.y {
-            y = p.y;
+            self.window.y = p.y;
         }
-
-        if x > 0 && y > 0 { self.window_ext(x, y) } else { self }
     }
 
-    pub fn map_mode(mut self, map_mode: MapMode) -> Self {
+    pub fn map_mode(&mut self, map_mode: MapMode) {
         self.map_mode = map_mode;
-        self
     }
 
-    pub fn poly_fill_mode(mut self, poly_fill_mode: PolyFillMode) -> Self {
+    pub fn poly_fill_mode(&mut self, poly_fill_mode: PolyFillMode) {
         self.poly_fill_mode = poly_fill_mode;
-        self
     }
 
     pub fn text_align_horizontal(
-        mut self,
+        &mut self,
         text_align_horizontal: TextAlignmentMode,
-    ) -> Self {
+    ) {
         self.text_align_horizontal = text_align_horizontal;
-        self
     }
 
     pub fn text_align_vertical(
-        mut self,
+        &mut self,
         text_align_vertical: VerticalTextAlignmentMode,
-    ) -> Self {
+    ) {
         self.text_align_vertical = text_align_vertical;
-        self
     }
 
-    pub fn text_align_update_cp(mut self, text_align_update_cp: bool) -> Self {
+    pub fn text_align_update_cp(&mut self, text_align_update_cp: bool) {
         self.text_align_update_cp = text_align_update_cp;
-        self
     }
 
-    pub fn text_bk_color(mut self, text_bk_color: ColorRef) -> Self {
+    pub fn text_bk_color(&mut self, text_bk_color: ColorRef) {
         self.text_bk_color = text_bk_color;
-        self
     }
 
-    pub fn text_color(mut self, text_color: ColorRef) -> Self {
+    pub fn text_color(&mut self, text_color: ColorRef) {
         self.text_color = text_color;
-        self
     }
 
-    pub fn window_ext(mut self, x: i16, y: i16) -> Self {
-        self.window = self.window.ext(x, y);
-        self
+    pub fn window_ext(&mut self, x: i16, y: i16) {
+        self.window.ext(x, y);
     }
 
-    pub fn window_origin(mut self, x: i16, y: i16) -> Self {
-        self.window = self.window.origin(x, y);
-        self
+    pub fn window_origin(&mut self, x: i16, y: i16) {
+        self.window.origin(x, y);
     }
 
-    pub fn window_scale(mut self, x: f32, y: f32) -> Self {
-        self.window = self.window.scale(x, y);
-        self
+    pub fn window_scale(&mut self, x: f32, y: f32) {
+        self.window.scale(x, y);
     }
 }
 
 impl DeviceContext {
+    pub fn text_y_offset(&self, font_height: i16) -> i16 {
+        if matches!(
+            self.text_align_vertical,
+            VerticalTextAlignmentMode::VTA_BASELINE
+                | VerticalTextAlignmentMode::VTA_BOTTOM
+        ) && font_height < 0
+        {
+            -font_height
+        } else {
+            0
+        }
+    }
+
     pub fn as_css_text_align(&self) -> String {
         match self.text_align_horizontal {
             TextAlignmentMode::TA_CENTER => "middle".to_owned(),
@@ -170,31 +165,37 @@ impl DeviceContext {
     }
 
     pub fn point_s_to_absolute_point(&self, point: &PointS) -> PointS {
-        let x = (f32::from((point.x - self.window.origin_x).abs())
-            / self.window.scale_x) as i16;
-        let y = (f32::from((point.y - self.window.origin_y).abs())
-            / self.window.scale_y) as i16;
+        let dx =
+            f32::from(point.x - self.window.origin_x) / self.window.scale_x;
+        let dy =
+            f32::from(point.y - self.window.origin_y) / self.window.scale_y;
+
+        // Negative extent means the axis is flipped
+        let x = (if self.window.flip_x { -dx } else { dx }) as i16;
+        let y = (if self.window.flip_y { -dy } else { dy }) as i16;
 
         PointS { x, y }
     }
 
     pub fn point_s_to_relative_point(&self, point: &PointS) -> PointS {
-        let x = (f32::from((point.x - self.window.origin_x).abs())
-            / self.window.scale_x) as i16
+        let dx =
+            f32::from(point.x - self.window.origin_x) / self.window.scale_x;
+        let dy =
+            f32::from(point.y - self.window.origin_y) / self.window.scale_y;
+
+        let x = (if self.window.flip_x { -dx } else { dx }) as i16
             + self.drawing_position.x;
-        let y = (f32::from((point.y - self.window.origin_y).abs())
-            / self.window.scale_y) as i16
+        let y = (if self.window.flip_y { -dy } else { dy }) as i16
             + self.drawing_position.y;
 
         PointS { x, y }
     }
 
-    pub fn poly_fill_rule(&self) -> String {
+    pub fn poly_fill_rule(&self) -> &'static str {
         match self.poly_fill_mode {
             PolyFillMode::ALTERNATE => "evenodd",
             PolyFillMode::WINDING => "nonzero",
         }
-        .to_owned()
     }
 
     pub fn text_color_as_css_color(&self) -> String {
@@ -210,6 +211,13 @@ pub struct Window {
     pub origin_y: i16,
     pub scale_x: f32,
     pub scale_y: f32,
+    /// Minimum rendered coordinates for viewBox expansion
+    pub min_x: i16,
+    pub min_y: i16,
+    /// Flip the axis when the extent is negative
+    /// (in WMF, a negative extent reverses the axis direction)
+    pub flip_x: bool,
+    pub flip_y: bool,
 }
 
 impl Default for Window {
@@ -221,6 +229,10 @@ impl Default for Window {
             origin_y: 0,
             scale_x: 1.0,
             scale_y: 1.0,
+            min_x: 0,
+            min_y: 0,
+            flip_x: false,
+            flip_y: false,
         }
     }
 }
@@ -230,25 +242,28 @@ impl Window {
         Self::default()
     }
 
-    pub fn ext(mut self, x: i16, y: i16) -> Self {
+    pub fn ext(&mut self, x: i16, y: i16) {
+        self.flip_x = x < 0;
+        self.flip_y = y < 0;
         self.x = x.abs();
         self.y = y.abs();
-        self
     }
 
-    pub fn origin(mut self, origin_x: i16, origin_y: i16) -> Self {
+    pub fn origin(&mut self, origin_x: i16, origin_y: i16) {
         self.origin_x = origin_x;
         self.origin_y = origin_y;
-        self
     }
 
-    pub fn scale(mut self, scale_x: f32, scale_y: f32) -> Self {
+    pub fn scale(&mut self, scale_x: f32, scale_y: f32) {
         self.scale_x = scale_x;
         self.scale_y = scale_y;
-        self
     }
 
     pub fn as_view_box(&self) -> (i16, i16, i16, i16) {
-        (0, 0, self.x.abs(), self.y.abs())
+        // Expand viewBox to include negative coordinates if any
+        let min_x = self.min_x.min(0);
+        let min_y = self.min_y.min(0);
+
+        (min_x, min_y, self.x - min_x, self.y - min_y)
     }
 }

--- a/core/src/converter/svg/device_context.rs
+++ b/core/src/converter/svg/device_context.rs
@@ -245,8 +245,14 @@ impl Window {
     pub fn ext(&mut self, x: i16, y: i16) {
         self.flip_x = x < 0;
         self.flip_y = y < 0;
-        self.x = i16::try_from(x.unsigned_abs()).unwrap_or(i16::MAX);
-        self.y = i16::try_from(y.unsigned_abs()).unwrap_or(i16::MAX);
+
+        let mag_x = i16::try_from(x.unsigned_abs()).unwrap_or(i16::MAX);
+        let mag_y = i16::try_from(y.unsigned_abs()).unwrap_or(i16::MAX);
+
+        // Preserve any previously tracked larger extents to avoid
+        // shrinking the viewBox and clipping already rendered content.
+        self.x = self.x.max(mag_x);
+        self.y = self.y.max(mag_y);
     }
 
     pub fn origin(&mut self, origin_x: i16, origin_y: i16) {

--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -938,15 +938,20 @@ impl crate::converter::Player for SVGPlayer {
 
         let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
+        let p1 = self.convert_point(record.x_left, record.y_left);
+        let p2 = self.convert_point(
+            record.x_left + record.width,
+            record.y_left + record.height,
+        );
 
         let rect = Node::new("rect")
             .set("fill", fill.as_str())
             .set("fill-rule", fill_rule)
             .set("stroke", "none")
-            .set("x", record.x_left)
-            .set("y", record.y_left)
-            .set("height", record.height)
-            .set("width", record.width);
+            .set("x", p1.x.min(p2.x))
+            .set("y", p1.y.min(p2.y))
+            .set("height", (p2.y - p1.y).abs())
+            .set("width", (p2.x - p1.x).abs());
 
         self.push_element(record_number, rect);
 
@@ -1153,16 +1158,16 @@ impl crate::converter::Player for SVGPlayer {
         let stroke = Stroke::from(self.selected_pen());
         let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
-        let tl = self.convert_point(record.left_rect, record.top_rect);
-        let br = self.convert_point(record.right_rect, record.bottom_rect);
+        let p1 = self.convert_point(record.left_rect, record.top_rect);
+        let p2 = self.convert_point(record.right_rect, record.bottom_rect);
 
         let rect = Node::new("rect")
             .set("fill", fill.as_str())
             .set("fill-rule", fill_rule)
-            .set("x", tl.x)
-            .set("y", tl.y)
-            .set("height", br.y - tl.y)
-            .set("width", br.x - tl.x);
+            .set("x", p1.x.min(p2.x))
+            .set("y", p1.y.min(p2.y))
+            .set("height", (p2.y - p1.y).abs())
+            .set("width", (p2.x - p1.x).abs());
         let rect = stroke.set_props(rect);
 
         self.push_element(record_number, rect);
@@ -1180,10 +1185,14 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_ROUNDRECT,
     ) -> Result<Self, PlayError> {
-        let (width, height) = (
-            record.right_rect - record.left_rect,
-            record.bottom_rect - record.top_rect,
-        );
+        let stroke = Stroke::from(self.selected_pen());
+        let fill = self.resolve_fill();
+        let fill_rule = self.context_current.poly_fill_rule();
+        let p1 = self.convert_point(record.left_rect, record.top_rect);
+        let p2 = self.convert_point(record.right_rect, record.bottom_rect);
+
+        let width = (p2.x - p1.x).abs();
+        let height = (p2.y - p1.y).abs();
 
         if width == 0 || height == 0 {
             info!(
@@ -1194,16 +1203,11 @@ impl crate::converter::Player for SVGPlayer {
             return Ok(self);
         }
 
-        let stroke = Stroke::from(self.selected_pen());
-        let fill = self.resolve_fill();
-        let fill_rule = self.context_current.poly_fill_rule();
-        let point = self.convert_point(record.left_rect, record.top_rect);
-
         let rect = Node::new("rect")
             .set("fill", fill.as_str())
             .set("fill-rule", fill_rule)
-            .set("x", point.x)
-            .set("y", point.y)
+            .set("x", p1.x.min(p2.x))
+            .set("y", p1.y.min(p2.y))
             .set("height", height)
             .set("width", width)
             .set("rx", record.width)

--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -5,7 +5,7 @@ mod util;
 
 use crate::{
     converter::{
-        GraphicsObject, PlayError, SelectedGraphicsObject,
+        GraphicsObject, GraphicsObjects, PlayError, SelectedGraphicsObject,
         svg::{
             device_context::DeviceContext,
             node::{Data, Node},
@@ -56,6 +56,52 @@ impl SVGPlayer {
 
     fn selected_pen(&self) -> &Pen {
         &self.object_selected.pen
+    }
+
+    fn resolve_fill(&mut self) -> String {
+        match Fill::from(self.selected_brush()) {
+            Fill::Pattern { pattern } => {
+                let id = self.issue_definition_id();
+                self.definitions.push(pattern.set("id", id.as_str()));
+                url_string(format!("#{id}").as_str())
+            }
+            Fill::Value { value } => value,
+        }
+    }
+
+    fn run_raster_operator(
+        &mut self,
+        record_number: usize,
+        operator: TernaryRasterOperator,
+    ) -> Result<(), PlayError> {
+        let Some(elem) =
+            operator.run(&mut self.definitions).map_err(|err| {
+                PlayError::InvalidRecord { cause: err.to_string() }
+            })?
+        else {
+            return Ok(());
+        };
+
+        self.push_element(record_number, elem);
+        Ok(())
+    }
+
+    fn convert_point(&mut self, x: i16, y: i16) -> PointS {
+        let point =
+            self.context_current.point_s_to_absolute_point(&PointS { x, y });
+        self.context_current.extend_window(&point);
+        point
+    }
+
+    fn convert_point_for_text(&mut self, x: i16, y: i16) -> PointS {
+        let src = PointS { x, y };
+        let point = if self.context_current.text_align_update_cp {
+            self.context_current.point_s_to_relative_point(&src)
+        } else {
+            self.context_current.point_s_to_absolute_point(&src)
+        };
+        self.context_current.extend_window(&point);
+        point
     }
 }
 
@@ -156,16 +202,7 @@ impl crate::converter::Player for SVGPlayer {
             }
         };
 
-        let Some(elem) =
-            operator.run(&mut self.definitions).map_err(|err| {
-                PlayError::InvalidRecord { cause: err.to_string() }
-            })?
-        else {
-            return Ok(self);
-        };
-
-        self.push_element(record_number, elem);
-
+        self.run_raster_operator(record_number, operator)?;
         Ok(self)
     }
 
@@ -231,16 +268,7 @@ impl crate::converter::Player for SVGPlayer {
             }
         };
 
-        let Some(elem) =
-            operator.run(&mut self.definitions).map_err(|err| {
-                PlayError::InvalidRecord { cause: err.to_string() }
-            })?
-        else {
-            return Ok(self);
-        };
-
-        self.push_element(record_number, elem);
-
+        self.run_raster_operator(record_number, operator)?;
         Ok(self)
     }
 
@@ -306,16 +334,7 @@ impl crate::converter::Player for SVGPlayer {
             }
         };
 
-        let Some(elem) =
-            operator.run(&mut self.definitions).map_err(|err| {
-                PlayError::InvalidRecord { cause: err.to_string() }
-            })?
-        else {
-            return Ok(self);
-        };
-
-        self.push_element(record_number, elem);
-
+        self.run_raster_operator(record_number, operator)?;
         Ok(self)
     }
 
@@ -395,16 +414,7 @@ impl crate::converter::Player for SVGPlayer {
             }
         };
 
-        let Some(elem) =
-            operator.run(&mut self.definitions).map_err(|err| {
-                PlayError::InvalidRecord { cause: err.to_string() }
-            })?
-        else {
-            return Ok(self);
-        };
-
-        self.push_element(record_number, elem);
-
+        self.run_raster_operator(record_number, operator)?;
         Ok(self)
     }
 
@@ -444,16 +454,7 @@ impl crate::converter::Player for SVGPlayer {
             operator = operator.source_bitmap(dib);
         }
 
-        let Some(elem) =
-            operator.run(&mut self.definitions).map_err(|err| {
-                PlayError::InvalidRecord { cause: err.to_string() }
-            })?
-        else {
-            return Ok(self);
-        };
-
-        self.push_element(record_number, elem);
-
+        self.run_raster_operator(record_number, operator)?;
         Ok(self)
     }
 
@@ -491,14 +492,11 @@ impl crate::converter::Player for SVGPlayer {
         if let Some(placeable) = placeable {
             let Rect { left, top, right, bottom } = placeable.bounding_box;
 
-            self.context_current = self
-                .context_current
-                .window_origin(left, top)
-                .window_ext(right - left, bottom - top);
+            self.context_current.window_origin(left, top);
+            self.context_current.window_ext(right - left, bottom - top);
         }
 
-        self.context_current =
-            self.context_current.create_object_table(header.number_of_objects);
+        self.context_current.create_object_table(header.number_of_objects);
 
         Ok(self)
     }
@@ -519,27 +517,9 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_ARC,
     ) -> Result<Self, PlayError> {
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let start = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.x_start_arc,
-                    y: record.y_start_arc,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
-        let end = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.x_end_arc,
-                    y: record.y_end_arc,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let start = self.convert_point(record.x_start_arc, record.y_start_arc);
+        let end = self.convert_point(record.x_end_arc, record.y_end_arc);
         let (rx, ry) = (
             (record.right_rect - record.left_rect) / 2,
             (record.bottom_rect - record.top_rect) / 2,
@@ -571,7 +551,7 @@ impl crate::converter::Player for SVGPlayer {
         let path = Node::new("path").set("fill", "none").set("d", data);
         let path = stroke.set_props(path);
 
-        self.context_current = self.context_current.drawing_position(end);
+        self.context_current.drawing_position(end);
         self.push_element(record_number, path);
 
         Ok(self)
@@ -612,16 +592,9 @@ impl crate::converter::Player for SVGPlayer {
 
         // Build SVG path for chord: move to first radial, draw arc, line to
         // center, close path
-        let fill = match Fill::from(self.selected_brush().clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
-        let stroke = Stroke::from(self.selected_pen().clone());
+        let stroke = Stroke::from(self.selected_pen());
 
         // SVG arc parameters:
         // - always small arc (large_arc=0)
@@ -638,7 +611,7 @@ impl crate::converter::Player for SVGPlayer {
             .close();
         let path = Node::new("path")
             .set("fill", fill.as_str())
-            .set("fill-rule", fill_rule.as_str())
+            .set("fill-rule", fill_rule)
             .set("d", data);
         let path = stroke.set_props(path);
 
@@ -671,30 +644,15 @@ impl crate::converter::Player for SVGPlayer {
             return Ok(self);
         }
 
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let fill = match Fill::from(self.selected_brush().clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
-        let point = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.left_rect + rx,
-                    y: record.top_rect + ry,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let point =
+            self.convert_point(record.left_rect + rx, record.top_rect + ry);
 
         let ellipse = Node::new("ellipse")
             .set("fill", fill.as_str())
-            .set("fill-rule", fill_rule.as_str())
+            .set("fill-rule", fill_rule)
             .set("cx", point.x)
             .set("cy", point.y)
             .set("rx", rx)
@@ -733,10 +691,12 @@ impl crate::converter::Player for SVGPlayer {
         use unicode_segmentation::UnicodeSegmentation;
         use unicode_width::UnicodeWidthStr;
 
-        let font = &self.object_selected.font;
-        let text_content = record.into_utf8(font.charset).map_err(|err| {
+        let font_charset = self.object_selected.font.charset;
+        let font_height = self.object_selected.font.height;
+        let text_content = record.into_utf8(font_charset).map_err(|err| {
             PlayError::InvalidRecord { cause: err.to_string() }
         })?;
+        let y_offset = self.context_current.text_y_offset(font_height);
         let point = {
             let point = PointS {
                 x: if self.context_current.text_align_update_cp {
@@ -748,25 +708,17 @@ impl crate::converter::Player for SVGPlayer {
                     self.context_current.drawing_position.y
                 } else {
                     record.y
-                } + (if matches!(
-                    self.context_current.text_align_vertical,
-                    VerticalTextAlignmentMode::VTA_BASELINE
-                        | VerticalTextAlignmentMode::VTA_BOTTOM
-                ) && font.height < 0
-                {
-                    -font.height
-                } else {
-                    0
-                }),
+                } + y_offset,
             };
 
+            // update_cp == true: already in SVG space, no conversion
             let point = if self.context_current.text_align_update_cp {
                 point
             } else {
                 self.context_current.point_s_to_absolute_point(&point)
             };
 
-            self.context_current = self.context_current.extend_window(&point);
+            self.context_current.extend_window(&point);
             point
         };
         let text_align = self.context_current.as_css_text_align();
@@ -774,54 +726,10 @@ impl crate::converter::Player for SVGPlayer {
             record.fw_opts.contains(&ExtTextOutOptions::ETO_CLIPPED),
             record.rectangle,
         ) {
-            let tl = {
-                let point = PointS { x: rect.left, y: rect.top };
-                let point = if self.context_current.text_align_update_cp {
-                    self.context_current.point_s_to_relative_point(&point)
-                } else {
-                    self.context_current.point_s_to_absolute_point(&point)
-                };
-
-                self.context_current =
-                    self.context_current.extend_window(&point);
-                point
-            };
-            let tr = {
-                let point = PointS { x: rect.right, y: rect.top };
-                let point = if self.context_current.text_align_update_cp {
-                    self.context_current.point_s_to_relative_point(&point)
-                } else {
-                    self.context_current.point_s_to_absolute_point(&point)
-                };
-
-                self.context_current =
-                    self.context_current.extend_window(&point);
-                point
-            };
-            let bl = {
-                let point = PointS { x: rect.left, y: rect.bottom };
-                let point = if self.context_current.text_align_update_cp {
-                    self.context_current.point_s_to_relative_point(&point)
-                } else {
-                    self.context_current.point_s_to_absolute_point(&point)
-                };
-
-                self.context_current =
-                    self.context_current.extend_window(&point);
-                point
-            };
-            let br = {
-                let point = PointS { x: rect.right, y: rect.bottom };
-                let point = if self.context_current.text_align_update_cp {
-                    self.context_current.point_s_to_relative_point(&point)
-                } else {
-                    self.context_current.point_s_to_absolute_point(&point)
-                };
-
-                self.context_current =
-                    self.context_current.extend_window(&point);
-                point
-            };
+            let tl = self.convert_point_for_text(rect.left, rect.top);
+            let tr = self.convert_point_for_text(rect.right, rect.top);
+            let bl = self.convert_point_for_text(rect.left, rect.bottom);
+            let br = self.convert_point_for_text(rect.right, rect.bottom);
 
             Some(format!(
                 "shape-inside: polygon({} {} {} {});",
@@ -858,7 +766,7 @@ impl crate::converter::Player for SVGPlayer {
                 let mut tspan = Node::new("tspan").add(Node::new_text(s));
 
                 if dx != 0 {
-                    let excess_dx = (font.height.abs() / 2)
+                    let excess_dx = (font_height.abs() / 2)
                         * i16::try_from(s.width()).unwrap_or(0);
                     let dx = core::cmp::max(dx - excess_dx, 0);
 
@@ -881,10 +789,10 @@ impl crate::converter::Player for SVGPlayer {
         }
 
         if self.context_current.text_align_update_cp {
-            let dx = (font.height.abs() / 2)
+            let dx = (font_height.abs() / 2)
                 * i16::try_from(text_content.width()).unwrap_or(0);
             let point = PointS { x: point.x + dx, y: point.y };
-            self.context_current = self.context_current.drawing_position(point);
+            self.context_current.drawing_position(point);
         }
 
         // HACK: background color
@@ -975,17 +883,8 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_LINETO,
     ) -> Result<Self, PlayError> {
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let point = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.x,
-                    y: record.y,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let point = self.convert_point(record.x, record.y);
 
         let data = Data::new()
             .move_to(format!(
@@ -997,7 +896,7 @@ impl crate::converter::Player for SVGPlayer {
         let path = Node::new("path").set("fill", "none").set("d", data);
         let path = stroke.set_props(path);
 
-        self.context_current = self.context_current.drawing_position(point);
+        self.context_current.drawing_position(point);
         self.push_element(record_number, path);
 
         Ok(self)
@@ -1037,19 +936,12 @@ impl crate::converter::Player for SVGPlayer {
             return Ok(self);
         }
 
-        let fill = match Fill::from(self.selected_brush().clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
 
         let rect = Node::new("rect")
             .set("fill", fill.as_str())
-            .set("fill-rule", fill_rule.as_str())
+            .set("fill-rule", fill_rule)
             .set("stroke", "none")
             .set("x", record.x_left)
             .set("y", record.y_left)
@@ -1071,16 +963,8 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_PIE,
     ) -> Result<Self, PlayError> {
-        let brush = self.selected_brush();
-        let stroke = Stroke::from(brush.clone());
-        let fill = match Fill::from(brush.clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
         let (rx, ry) = (
             (record.right_rect - record.left_rect) / 2,
@@ -1091,43 +975,16 @@ impl crate::converter::Player for SVGPlayer {
 
         let ellipse = Node::new("ellipse")
             .set("fill", fill.as_str())
-            .set("fill-rule", fill_rule.as_str())
+            .set("fill-rule", fill_rule)
             .set("cx", center_x)
             .set("cy", center_y)
             .set("rx", rx)
             .set("ry", ry);
         let ellipse = stroke.set_props(ellipse);
 
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let p1 = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.x_radial1,
-                    y: record.y_radial1,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
-        let center = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: center_x,
-                    y: center_y,
-                });
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
-        let p2 = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.x_radial2,
-                    y: record.y_radial2,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let p1 = self.convert_point(record.x_radial1, record.y_radial1);
+        let center = self.convert_point(center_x, center_y);
+        let p2 = self.convert_point(record.x_radial2, record.y_radial2);
 
         let data = Data::new()
             .move_to(format!("{} {}", p1.x, p1.y))
@@ -1136,7 +993,7 @@ impl crate::converter::Player for SVGPlayer {
         let path = Node::new("path").set("fill", "none").set("d", data);
         let path = stroke.set_props(path);
 
-        self.context_current = self.context_current.drawing_position(p2);
+        self.context_current.drawing_position(p2);
         self.push_element(record_number, ellipse);
         self.push_element(record_number, path);
 
@@ -1153,18 +1010,14 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_POLYLINE,
     ) -> Result<Self, PlayError> {
-        let stroke = Stroke::from(self.selected_pen().clone());
+        let stroke = Stroke::from(self.selected_pen());
         let Some(point) = record.a_points.first() else {
             return Err(PlayError::InvalidRecord {
                 cause: "aPoints[0] is not defined".to_owned(),
             });
         };
 
-        let mut coordinate = {
-            let point = self.context_current.point_s_to_absolute_point(point);
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let mut coordinate = self.convert_point(point.x, point.y);
 
         let mut data =
             Data::new().move_to(format!("{} {}", coordinate.x, coordinate.y));
@@ -1176,13 +1029,7 @@ impl crate::converter::Player for SVGPlayer {
                 });
             };
 
-            coordinate = {
-                let point =
-                    self.context_current.point_s_to_absolute_point(point);
-                self.context_current =
-                    self.context_current.extend_window(&point);
-                point
-            };
+            coordinate = self.convert_point(point.x, point.y);
 
             data = data.line_to(format!("{} {}", coordinate.x, coordinate.y));
         }
@@ -1190,8 +1037,7 @@ impl crate::converter::Player for SVGPlayer {
         let path = Node::new("path").set("fill", "none").set("d", data);
         let path = stroke.set_props(path);
 
-        self.context_current =
-            self.context_current.drawing_position(coordinate);
+        self.context_current.drawing_position(coordinate);
         self.push_element(record_number, path);
 
         Ok(self)
@@ -1212,15 +1058,8 @@ impl crate::converter::Player for SVGPlayer {
             return Ok(self);
         }
 
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let fill = match Fill::from(self.selected_brush().clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
 
         let mut points = Vec::with_capacity(record.number_of_points as usize);
@@ -1232,20 +1071,13 @@ impl crate::converter::Player for SVGPlayer {
                 });
             };
 
-            let point = {
-                let point =
-                    self.context_current.point_s_to_absolute_point(point);
-                self.context_current =
-                    self.context_current.extend_window(&point);
-                point
-            };
-
+            let point = self.convert_point(point.x, point.y);
             points.push(as_point_string(&point));
         }
 
         let polygon = Node::new("polygon")
             .set("fill", fill.as_str())
-            .set("fill-rule", fill_rule.as_str())
+            .set("fill-rule", fill_rule)
             .set("points", points.join(" "));
         let polygon = stroke.set_props(polygon);
 
@@ -1264,19 +1096,12 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_POLYPOLYGON,
     ) -> Result<Self, PlayError> {
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let fill = match Fill::from(self.selected_brush().clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
 
         let mut a_point: VecDeque<_> = record.poly_polygon.a_points.into();
-        let mut current_point_index = 0;
+        let total_points = a_point.len();
 
         for i in 0..record.poly_polygon.number_of_polygons {
             let Some(points_of_polygon) =
@@ -1293,26 +1118,19 @@ impl crate::converter::Player for SVGPlayer {
                 let Some(point) = a_point.pop_front() else {
                     return Err(PlayError::InvalidRecord {
                         cause: format!(
-                            "aPoints[{current_point_index}] is not defined"
+                            "aPoints[{}] is not defined",
+                            total_points - a_point.len(),
                         ),
                     });
                 };
 
-                let point = {
-                    let point =
-                        self.context_current.point_s_to_absolute_point(&point);
-                    self.context_current =
-                        self.context_current.extend_window(&point);
-                    point
-                };
-
+                let point = self.convert_point(point.x, point.y);
                 points.push(as_point_string(&point));
-                current_point_index += 1;
             }
 
             let polygon = Node::new("polygon")
                 .set("fill", fill.as_str())
-                .set("fill-rule", fill_rule.as_str())
+                .set("fill-rule", fill_rule)
                 .set("points", points.join(" "));
             let polygon = stroke.set_props(polygon);
 
@@ -1332,40 +1150,15 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_RECTANGLE,
     ) -> Result<Self, PlayError> {
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let fill = match Fill::from(self.selected_brush().clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
-        let tl = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.left_rect,
-                    y: record.top_rect,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
-        let br = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.right_rect,
-                    y: record.bottom_rect,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let tl = self.convert_point(record.left_rect, record.top_rect);
+        let br = self.convert_point(record.right_rect, record.bottom_rect);
 
         let rect = Node::new("rect")
             .set("fill", fill.as_str())
-            .set("fill-rule", fill_rule.as_str())
+            .set("fill-rule", fill_rule)
             .set("x", tl.x)
             .set("y", tl.y)
             .set("height", br.y - tl.y)
@@ -1401,30 +1194,14 @@ impl crate::converter::Player for SVGPlayer {
             return Ok(self);
         }
 
-        let stroke = Stroke::from(self.selected_pen().clone());
-        let fill = match Fill::from(self.selected_brush().clone()) {
-            Fill::Pattern { pattern } => {
-                let id = self.issue_definition_id();
-                self.definitions.push(pattern.set("id", id.as_str()));
-                url_string(format!("#{id}").as_str())
-            }
-            Fill::Value { value } => value,
-        };
+        let stroke = Stroke::from(self.selected_pen());
+        let fill = self.resolve_fill();
         let fill_rule = self.context_current.poly_fill_rule();
-        let point = {
-            let point =
-                self.context_current.point_s_to_absolute_point(&PointS {
-                    x: record.left_rect,
-                    y: record.top_rect,
-                });
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let point = self.convert_point(record.left_rect, record.top_rect);
 
         let rect = Node::new("rect")
             .set("fill", fill.as_str())
-            .set("fill-rule", fill_rule.as_str())
+            .set("fill-rule", fill_rule)
             .set("x", point.x)
             .set("y", point.y)
             .set("height", height)
@@ -1462,35 +1239,14 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_TEXTOUT,
     ) -> Result<Self, PlayError> {
-        let font = &self.object_selected.font;
-        let text_content = record.into_utf8(font.charset).map_err(|err| {
+        let font_charset = self.object_selected.font.charset;
+        let font_height = self.object_selected.font.height;
+        let text_content = record.into_utf8(font_charset).map_err(|err| {
             PlayError::InvalidRecord { cause: err.to_string() }
         })?;
-        let point = {
-            let point = PointS {
-                x: record.x_start,
-                y: record.y_start
-                    + (if matches!(
-                        self.context_current.text_align_vertical,
-                        VerticalTextAlignmentMode::VTA_BASELINE
-                            | VerticalTextAlignmentMode::VTA_BOTTOM
-                    ) && font.height < 0
-                    {
-                        -font.height
-                    } else {
-                        0
-                    }),
-            };
-
-            let point = if self.context_current.text_align_update_cp {
-                self.context_current.point_s_to_relative_point(&point)
-            } else {
-                self.context_current.point_s_to_absolute_point(&point)
-            };
-
-            self.context_current = self.context_current.extend_window(&point);
-            point
-        };
+        let y_offset = self.context_current.text_y_offset(font_height);
+        let point = self
+            .convert_point_for_text(record.x_start, record.y_start + y_offset);
 
         let text = Node::new("text")
             .set("x", point.x)
@@ -1684,25 +1440,31 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SELECTOBJECT,
     ) -> Result<Self, PlayError> {
-        let object = self
-            .context_current
-            .object_table
-            .get(record.object_index as usize)
-            .clone();
-        let selected = self.object_selected.clone();
+        let object =
+            self.context_current.object_table.get(record.object_index as usize);
 
-        self.object_selected = match object {
-            GraphicsObject::Brush(v) => selected.brush(v),
-            GraphicsObject::Font(v) => selected.font(v),
-            GraphicsObject::Palette(v) => selected.palette(v),
-            GraphicsObject::Pen(v) => selected.pen(v),
-            GraphicsObject::Region(v) => selected.region(v),
+        match object {
+            GraphicsObject::Brush(v) => {
+                self.object_selected.set_brush(v.clone());
+            }
+            GraphicsObject::Font(v) => {
+                self.object_selected.set_font(v.clone());
+            }
+            GraphicsObject::Palette(v) => {
+                self.object_selected.set_palette(v.clone());
+            }
+            GraphicsObject::Pen(v) => {
+                self.object_selected.set_pen(v.clone());
+            }
+            GraphicsObject::Region(v) => {
+                self.object_selected.set_region(v.clone());
+            }
             GraphicsObject::Null => {
                 return Err(PlayError::UnexpectedGraphicsObject {
                     cause: "Graphics Object is null".to_owned(),
                 });
             }
-        };
+        }
 
         Ok(self)
     }
@@ -1726,7 +1488,7 @@ impl crate::converter::Player for SVGPlayer {
             });
         };
 
-        self.object_selected = self.object_selected.palette(palette.clone());
+        self.object_selected.set_palette(palette.clone());
 
         Ok(self)
     }
@@ -1776,12 +1538,7 @@ impl crate::converter::Player for SVGPlayer {
     ) -> Result<Self, PlayError> {
         let META_INTERSECTCLIPRECT { bottom, right, top, left, .. } = record;
 
-        self.context_current = self.context_current.clipping_region(Rect {
-            left,
-            top,
-            right,
-            bottom,
-        });
+        self.context_current.clipping_region(Rect { left, top, right, bottom });
 
         Ok(self)
     }
@@ -1796,11 +1553,8 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_MOVETO,
     ) -> Result<Self, PlayError> {
-        let point = self
-            .context_current
-            .point_s_to_absolute_point(&PointS { x: record.x, y: record.y });
-        self.context_current =
-            self.context_current.extend_window(&point).drawing_position(point);
+        let point = self.convert_point(record.x, record.y);
+        self.context_current.drawing_position(point);
 
         Ok(self)
     }
@@ -1885,16 +1639,49 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_RESTOREDC,
     ) -> Result<Self, PlayError> {
-        let context = if record.n_saved_dc < 0 {
-            self.context_current.clone().into()
-        } else if (record.n_saved_dc as usize) < self.context_stack.len() {
-            self.context_stack.remove(record.n_saved_dc as usize).into()
-        } else {
-            None
+        // MS-WMF spec:
+        // Negative: relative offset from the top of the stack
+        //   (-1 = most recent, -2 = one before that, ...)
+        // Positive: 1-based absolute index
+        // In both cases, all entries saved after the target are discarded
+        let index = match record.n_saved_dc.cmp(&0) {
+            core::cmp::Ordering::Less => {
+                let offset = record.n_saved_dc.unsigned_abs() as usize;
+
+                self.context_stack.len().checked_sub(offset)
+            }
+            core::cmp::Ordering::Greater => {
+                let idx = (record.n_saved_dc as usize) - 1;
+
+                if idx < self.context_stack.len() { Some(idx) } else { None }
+            }
+            core::cmp::Ordering::Equal => None,
         };
 
-        if let Some(ctx) = context {
-            self.context_current = ctx;
+        if let Some(idx) = index {
+            // Object Table is not subject to save/restore
+            let object_table = core::mem::replace(
+                &mut self.context_current.object_table,
+                GraphicsObjects::new(0),
+            );
+            // viewBox tracking values are not subject to save/restore
+            // (preserve the visible bounds of already-rendered elements)
+            let window_min_x = self.context_current.window.min_x;
+            let window_min_y = self.context_current.window.min_y;
+            let window_max_x = self.context_current.window.x;
+            let window_max_y = self.context_current.window.y;
+
+            self.context_current = self.context_stack[idx].clone();
+            self.context_current.object_table = object_table;
+            self.context_current.window.min_x =
+                window_min_x.min(self.context_current.window.min_x);
+            self.context_current.window.min_y =
+                window_min_y.min(self.context_current.window.min_y);
+            self.context_current.window.x =
+                window_max_x.max(self.context_current.window.x);
+            self.context_current.window.y =
+                window_max_y.max(self.context_current.window.y);
+            self.context_stack.truncate(idx);
         }
 
         Ok(self)
@@ -1939,6 +1726,16 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SCALEWINDOWEXT,
     ) -> Result<Self, PlayError> {
+        if record.x_denom == 0 || record.y_denom == 0 {
+            return Err(PlayError::InvalidRecord {
+                cause: format!(
+                    "META_SCALEWINDOWEXT has zero denominator: x_denom={}, \
+                     y_denom={}",
+                    record.x_denom, record.y_denom,
+                ),
+            });
+        }
+
         let scale_x = (self.context_current.window.scale_x
             * f32::from(record.x_num))
             / f32::from(record.x_denom);
@@ -1946,8 +1743,7 @@ impl crate::converter::Player for SVGPlayer {
             * f32::from(record.y_num))
             / f32::from(record.y_denom);
 
-        self.context_current =
-            self.context_current.window_scale(scale_x, scale_y);
+        self.context_current.window_scale(scale_x, scale_y);
 
         Ok(self)
     }
@@ -1962,8 +1758,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETBKCOLOR,
     ) -> Result<Self, PlayError> {
-        self.context_current =
-            self.context_current.text_bk_color(record.color_ref);
+        self.context_current.text_bk_color(record.color_ref);
 
         Ok(self)
     }
@@ -1978,7 +1773,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETBKMODE,
     ) -> Result<Self, PlayError> {
-        self.context_current = self.context_current.bk_mode(record.bk_mode);
+        self.context_current.bk_mode(record.bk_mode);
 
         Ok(self)
     }
@@ -2007,7 +1802,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETMAPMODE,
     ) -> Result<Self, PlayError> {
-        self.context_current = self.context_current.map_mode(record.map_mode);
+        self.context_current.map_mode(record.map_mode);
 
         Ok(self)
     }
@@ -2050,8 +1845,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETPOLYFILLMODE,
     ) -> Result<Self, PlayError> {
-        self.context_current =
-            self.context_current.poly_fill_mode(record.poly_fill_mode);
+        self.context_current.poly_fill_mode(record.poly_fill_mode);
 
         Ok(self)
     }
@@ -2080,7 +1874,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETROP2,
     ) -> Result<Self, PlayError> {
-        self.context_current = self.context_current.draw_mode(record.draw_mode);
+        self.context_current.draw_mode(record.draw_mode);
 
         Ok(self)
     }
@@ -2125,11 +1919,9 @@ impl crate::converter::Player for SVGPlayer {
         .find(|a| record.text_alignment_mode & (*a as u16) == *a as u16)
         .unwrap_or(VerticalTextAlignmentMode::VTA_BASELINE);
 
-        self.context_current = self
-            .context_current
-            .text_align_update_cp(update_cp)
-            .text_align_horizontal(align_horizontal)
-            .text_align_vertical(align_vertical);
+        self.context_current.text_align_update_cp(update_cp);
+        self.context_current.text_align_horizontal(align_horizontal);
+        self.context_current.text_align_vertical(align_vertical);
 
         Ok(self)
     }
@@ -2158,8 +1950,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETTEXTCOLOR,
     ) -> Result<Self, PlayError> {
-        self.context_current =
-            self.context_current.text_color(record.color_ref);
+        self.context_current.text_color(record.color_ref);
 
         Ok(self)
     }
@@ -2216,8 +2007,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETWINDOWEXT,
     ) -> Result<Self, PlayError> {
-        self.context_current =
-            self.context_current.window_ext(record.x, record.y);
+        self.context_current.window_ext(record.x, record.y);
 
         Ok(self)
     }
@@ -2232,8 +2022,7 @@ impl crate::converter::Player for SVGPlayer {
         record_number: usize,
         record: META_SETWINDOWORG,
     ) -> Result<Self, PlayError> {
-        self.context_current =
-            self.context_current.window_origin(record.x, record.y);
+        self.context_current.window_origin(record.x, record.y);
 
         Ok(self)
     }

--- a/core/src/converter/svg/node.rs
+++ b/core/src/converter/svg/node.rs
@@ -93,40 +93,56 @@ impl Data {
         Self::default()
     }
 
-    fn push_command(&mut self, cmd: &str, param: &str) {
+    fn push_command(
+        &mut self,
+        cmd: &str,
+        param: impl core::fmt::Display,
+    ) {
+        use core::fmt::Write;
+
         if !self.0.is_empty() {
             self.0.push(' ');
         }
 
         self.0.push_str(cmd);
-
-        if !param.is_empty() {
-            self.0.push(' ');
-            self.0.push_str(param);
-        }
+        self.0.push(' ');
+        let _ = write!(self.0, "{param}");
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand
     pub fn close(mut self) -> Self {
-        self.push_command("Z", "");
+        if !self.0.is_empty() {
+            self.0.push(' ');
+        }
+
+        self.0.push('Z');
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
-    pub fn elliptical_arc_to(mut self, param: impl core::fmt::Display) -> Self {
-        self.push_command("A", &param.to_string());
+    pub fn elliptical_arc_to(
+        mut self,
+        param: impl core::fmt::Display,
+    ) -> Self {
+        self.push_command("A", param);
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataLinetoCommands
-    pub fn line_to(mut self, param: impl core::fmt::Display) -> Self {
-        self.push_command("L", &param.to_string());
+    pub fn line_to(
+        mut self,
+        param: impl core::fmt::Display,
+    ) -> Self {
+        self.push_command("L", param);
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataMovetoCommands
-    pub fn move_to(mut self, param: impl core::fmt::Display) -> Self {
-        self.push_command("M", &param.to_string());
+    pub fn move_to(
+        mut self,
+        param: impl core::fmt::Display,
+    ) -> Self {
+        self.push_command("M", param);
         self
     }
 }

--- a/core/src/converter/svg/node.rs
+++ b/core/src/converter/svg/node.rs
@@ -93,11 +93,7 @@ impl Data {
         Self::default()
     }
 
-    fn push_command(
-        &mut self,
-        cmd: &str,
-        param: impl core::fmt::Display,
-    ) {
+    fn push_command(&mut self, cmd: &str, param: impl core::fmt::Display) {
         use core::fmt::Write;
 
         if !self.0.is_empty() {
@@ -120,28 +116,19 @@ impl Data {
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
-    pub fn elliptical_arc_to(
-        mut self,
-        param: impl core::fmt::Display,
-    ) -> Self {
+    pub fn elliptical_arc_to(mut self, param: impl core::fmt::Display) -> Self {
         self.push_command("A", param);
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataLinetoCommands
-    pub fn line_to(
-        mut self,
-        param: impl core::fmt::Display,
-    ) -> Self {
+    pub fn line_to(mut self, param: impl core::fmt::Display) -> Self {
         self.push_command("L", param);
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataMovetoCommands
-    pub fn move_to(
-        mut self,
-        param: impl core::fmt::Display,
-    ) -> Self {
+    pub fn move_to(mut self, param: impl core::fmt::Display) -> Self {
         self.push_command("M", param);
         self
     }

--- a/core/src/converter/svg/node.rs
+++ b/core/src/converter/svg/node.rs
@@ -64,21 +64,19 @@ impl core::fmt::Display for Node {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self.typ {
             NodeType::Node(name) => {
-                write!(
-                    f,
-                    "<{name} {}>{}</{name}>",
-                    self.attrs
-                        .iter()
-                        .map(|(k, v)| {
-                            format!(r#"{k}="{}""#, Self::escape_attr(v))
-                        })
-                        .collect::<Vec<_>>()
-                        .join(" "),
-                    self.inner
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<String>()
-                )
+                write!(f, "<{name}")?;
+
+                for (k, v) in &self.attrs {
+                    write!(f, r#" {k}="{}""#, Self::escape_attr(v))?;
+                }
+
+                write!(f, ">")?;
+
+                for child in &self.inner {
+                    write!(f, "{child}")?;
+                }
+
+                write!(f, "</{name}>")
             }
             NodeType::Text(value) => {
                 write!(f, "{}", Self::escape_text(value))
@@ -88,63 +86,53 @@ impl core::fmt::Display for Node {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct Data {
-    commands: Vec<String>,
-}
+pub struct Data(String);
 
 impl Data {
     pub fn new() -> Self {
         Self::default()
     }
 
+    fn push_command(&mut self, cmd: &str, param: &str) {
+        if !self.0.is_empty() {
+            self.0.push(' ');
+        }
+
+        self.0.push_str(cmd);
+
+        if !param.is_empty() {
+            self.0.push(' ');
+            self.0.push_str(param);
+        }
+    }
+
     /// https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand
     pub fn close(mut self) -> Self {
-        self.commands.push("Z".to_string());
+        self.push_command("Z", "");
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
-    pub fn elliptical_arc_to(mut self, param: impl Into<Parameters>) -> Self {
-        self.commands.push(format!("A {}", param.into().0));
+    pub fn elliptical_arc_to(mut self, param: impl core::fmt::Display) -> Self {
+        self.push_command("A", &param.to_string());
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataLinetoCommands
-    pub fn line_to(mut self, param: impl Into<Parameters>) -> Self {
-        self.commands.push(format!("L {}", param.into().0));
+    pub fn line_to(mut self, param: impl core::fmt::Display) -> Self {
+        self.push_command("L", &param.to_string());
         self
     }
 
     /// https://www.w3.org/TR/SVG/paths.html#PathDataMovetoCommands
-    pub fn move_to(mut self, param: impl Into<Parameters>) -> Self {
-        self.commands.push(format!("M {}", param.into().0));
+    pub fn move_to(mut self, param: impl core::fmt::Display) -> Self {
+        self.push_command("M", &param.to_string());
         self
     }
 }
 
 impl core::fmt::Display for Data {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.commands.join(" "))
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct Parameters(String);
-
-impl From<String> for Parameters {
-    fn from(v: String) -> Self {
-        Self(v)
-    }
-}
-
-impl From<&str> for Parameters {
-    fn from(v: &str) -> Self {
-        Self(v.to_owned())
-    }
-}
-
-impl From<Vec<String>> for Parameters {
-    fn from(v: Vec<String>) -> Self {
-        Self(v.join(" "))
+        f.write_str(&self.0)
     }
 }

--- a/core/src/converter/svg/ternary_raster_operator.rs
+++ b/core/src/converter/svg/ternary_raster_operator.rs
@@ -100,7 +100,7 @@ impl TernaryRasterOperator {
                     .set("href", bitmap.as_data_url())
             }
             TernaryRasterOperation::PATCOPY => {
-                let fill = match Fill::from(self.brush.clone().unwrap()) {
+                let fill = match Fill::from(self.brush.as_ref().unwrap()) {
                     Fill::Pattern { pattern } => {
                         let id = Self::issue_id(definitions);
                         definitions.push(pattern.set("id", id.as_str()));

--- a/core/src/converter/svg/util.rs
+++ b/core/src/converter/svg/util.rs
@@ -84,8 +84,8 @@ pub enum Fill {
     Value { value: String },
 }
 
-impl From<Brush> for Fill {
-    fn from(v: Brush) -> Self {
+impl From<&Brush> for Fill {
+    fn from(v: &Brush) -> Self {
         match v {
             Brush::DIBPatternPT { brush_hatch, .. } => {
                 let data = crate::converter::Bitmap::from(brush_hatch.clone())
@@ -113,28 +113,28 @@ impl From<Brush> for Fill {
                         let data = Data::new().move_to("0 0").line_to("10 0");
 
                         Node::new("path")
-                            .set("stroke", css_color_from_color_ref(&color_ref))
+                            .set("stroke", css_color_from_color_ref(color_ref))
                             .set("d", data)
                     }
                     HatchStyle::HS_VERTICAL => {
                         let data = Data::new().move_to("0 0").line_to("0 10");
 
                         Node::new("path")
-                            .set("stroke", css_color_from_color_ref(&color_ref))
+                            .set("stroke", css_color_from_color_ref(color_ref))
                             .set("d", data)
                     }
                     HatchStyle::HS_FDIAGONAL => {
                         let data = Data::new().move_to("0 10").line_to("10 0");
 
                         Node::new("path")
-                            .set("stroke", css_color_from_color_ref(&color_ref))
+                            .set("stroke", css_color_from_color_ref(color_ref))
                             .set("d", data)
                     }
                     HatchStyle::HS_BDIAGONAL => {
                         let data = Data::new().move_to("0 0").line_to("10 10");
 
                         Node::new("path")
-                            .set("stroke", css_color_from_color_ref(&color_ref))
+                            .set("stroke", css_color_from_color_ref(color_ref))
                             .set("d", data)
                     }
                     HatchStyle::HS_CROSS => {
@@ -145,7 +145,7 @@ impl From<Brush> for Fill {
                             .line_to("0 10");
 
                         Node::new("path")
-                            .set("stroke", css_color_from_color_ref(&color_ref))
+                            .set("stroke", css_color_from_color_ref(color_ref))
                             .set("d", data)
                     }
                     HatchStyle::HS_DIAGCROSS => {
@@ -156,7 +156,7 @@ impl From<Brush> for Fill {
                             .line_to("0 10");
 
                         Node::new("path")
-                            .set("stroke", css_color_from_color_ref(&color_ref))
+                            .set("stroke", css_color_from_color_ref(color_ref))
                             .set("d", data)
                     }
                 };
@@ -195,7 +195,7 @@ impl From<Brush> for Fill {
                 Fill::Pattern { pattern }
             }
             Brush::Solid { color_ref } => {
-                Fill::Value { value: css_color_from_color_ref(&color_ref) }
+                Fill::Value { value: css_color_from_color_ref(color_ref) }
             }
             Brush::Null => Fill::Value { value: "none".to_owned() },
         }
@@ -234,8 +234,8 @@ impl Default for Stroke {
     }
 }
 
-impl From<Pen> for Stroke {
-    fn from(v: Pen) -> Self {
+impl From<&Pen> for Stroke {
+    fn from(v: &Pen) -> Self {
         if v.style.style == PenStyle::PS_NULL {
             return Self { none: true, ..Default::default() };
         }
@@ -296,63 +296,24 @@ impl From<Pen> for Stroke {
             _ => {}
         }
 
-        stroke.color = v.color_ref;
+        stroke.color = v.color_ref.clone();
         stroke.width = if v.width.x == 0 { 1 } else { v.width.x };
         stroke
     }
 }
 
-impl From<Brush> for Stroke {
-    fn from(v: Brush) -> Self {
-        match v {
-            Brush::DIBPatternPT { .. } => {
-                Self { none: true, ..Default::default() }
-            }
-            Brush::Hatched { color_ref, .. } | Brush::Solid { color_ref } => {
-                Self { color: color_ref, ..Default::default() }
-            }
-            Brush::Pattern { .. } => Self { ..Default::default() },
-            Brush::Null => Self { none: true, width: 0, ..Default::default() },
-        }
-    }
-}
-
 impl Stroke {
-    pub fn color(&self) -> String {
-        css_color_from_color_ref(&self.color)
-    }
-
-    pub fn dash_array(&self) -> String {
-        self.dash_array.clone()
-    }
-
-    pub fn line_cap(&self) -> String {
-        self.line_cap.clone()
-    }
-
-    pub fn line_join(&self) -> String {
-        self.line_join.clone()
-    }
-
-    pub fn opacity(&self) -> String {
-        format!("{:.02}", self.opacity)
-    }
-
-    pub fn width(&self) -> i16 {
-        self.width
-    }
-
     pub fn set_props(&self, elem: Node) -> Node {
         if self.none {
             return elem.set("stroke", "none");
         }
 
-        elem.set("stroke", self.color())
-            .set("stroke-dasharray", self.dash_array())
-            .set("stroke-linecap", self.line_cap())
-            .set("stroke-linejoin", self.line_join())
-            .set("stroke-opacity", self.opacity())
-            .set("stroke-width", self.width())
+        elem.set("stroke", css_color_from_color_ref(&self.color))
+            .set("stroke-dasharray", &self.dash_array)
+            .set("stroke-linecap", &self.line_cap)
+            .set("stroke-linejoin", &self.line_join)
+            .set("stroke-opacity", format!("{:.02}", self.opacity))
+            .set("stroke-width", self.width)
     }
 }
 

--- a/core/tests/drawing/chord.rs
+++ b/core/tests/drawing/chord.rs
@@ -1,6 +1,6 @@
 use wmf_core::{
     converter::{Player, SVGPlayer},
-    parser::META_CHORD,
+    parser::{META_CHORD, META_SETWINDOWEXT},
 };
 
 #[test]
@@ -64,6 +64,17 @@ fn meta_chord_svg_table_test() {
 
     for (i, case) in cases.iter().enumerate() {
         let player = SVGPlayer::new();
+        let player = player
+            .set_window_ext(
+                0,
+                META_SETWINDOWEXT {
+                    record_size: 0.into(),
+                    record_function: 0,
+                    y: 1024,
+                    x: 1024,
+                },
+            )
+            .expect("set_window_ext failed");
         let result = player.chord(1, case.record.clone());
 
         assert!(result.is_ok(), "case {i}: {}: Rendering failed", case.desc);

--- a/core/tests/drawing/chord.rs
+++ b/core/tests/drawing/chord.rs
@@ -65,15 +65,12 @@ fn meta_chord_svg_table_test() {
     for (i, case) in cases.iter().enumerate() {
         let player = SVGPlayer::new();
         let player = player
-            .set_window_ext(
-                0,
-                META_SETWINDOWEXT {
-                    record_size: 0.into(),
-                    record_function: 0,
-                    y: 1024,
-                    x: 1024,
-                },
-            )
+            .set_window_ext(0, META_SETWINDOWEXT {
+                record_size: 0.into(),
+                record_function: 0,
+                y: 1024,
+                x: 1024,
+            })
             .expect("set_window_ext failed");
         let result = player.chord(1, case.record.clone());
 


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the bitmap conversion, graphics object management, and SVG device context handling in the codebase. The main themes are safer and more robust object management, improved coordinate and window handling for SVG output, and code modernization for better clarity and maintainability.

**Graphics object management and error handling:**
* Improved safety in `GraphicsObjects::delete` by adding bounds checking and logging a warning if an invalid index is used. Now, out-of-bounds deletions do not panic.
* Enhanced robustness in `GraphicsObjects::push` by logging a warning and ignoring pushes when the object table is full, rather than silently failing.

**SVG device context and window handling:**
* Refactored all mutation methods in `DeviceContext` and `Window` to use `&mut self` instead of consuming `self`, making state changes more idiomatic and efficient. [[1]](diffhunk://#diff-9f11816e1e2c96348c742b9666d186a6a41a106452fee4201e6c5f5d2ab6a192L48-R149) [[2]](diffhunk://#diff-9f11816e1e2c96348c742b9666d186a6a41a106452fee4201e6c5f5d2ab6a192L233-R267)
* Added `min_x`, `min_y`, `flip_x`, and `flip_y` fields to `Window` for accurate viewBox expansion and axis flipping, with corresponding logic in extent/origin/scale methods and viewBox calculation. This allows correct rendering of negative coordinates and axis direction reversal in WMF files. [[1]](diffhunk://#diff-9f11816e1e2c96348c742b9666d186a6a41a106452fee4201e6c5f5d2ab6a192R214-R220) [[2]](diffhunk://#diff-9f11816e1e2c96348c742b9666d186a6a41a106452fee4201e6c5f5d2ab6a192R232-R235) [[3]](diffhunk://#diff-9f11816e1e2c96348c742b9666d186a6a41a106452fee4201e6c5f5d2ab6a192L233-R267)
* Improved coordinate conversion methods (`point_s_to_absolute_point`, `point_s_to_relative_point`) to handle axis flipping and negative extents, ensuring SVG output matches the original WMF intent.
* Added a `text_y_offset` helper to `DeviceContext` for correct vertical text alignment in SVG output.

**Bitmap conversion and palette handling:**
* Simplified and corrected BMP file size and data offset calculations, and refactored palette extraction to use fixed-size arrays for color values, improving correctness and efficiency. [[1]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cL29) [[2]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cL40) [[3]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cL60) [[4]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cL95) [[5]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cL151) [[6]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cR184-R197) [[7]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cL317-R322) [[8]](diffhunk://#diff-d66439d855a701b03bf89c3b8a1371afa9892d953aba1e38bfea23045f343b6cL352-R350)

**API modernization and clarity:**
* Replaced builder-style methods in `SelectedGraphicsObject` with direct setters to avoid unnecessary object copying and clarify intent.
* Updated trait method signatures in `Player` to use the local `PlayError` type directly, improving readability. [[1]](diffhunk://#diff-b1db5b1637f2a125741a5f9d1338233ef8a37c3a48457f43ebdd00a833a3a74dL208-R208) [[2]](diffhunk://#diff-b1db5b1637f2a125741a5f9d1338233ef8a37c3a48457f43ebdd00a833a3a74dL252-R252)

**Parsing and error handling improvements:**
* Changed zero-sized record parsing to return an error instead of silently skipping, making unexpected input more visible.
* Added logging for vendor-specific `META_ESCAPE` parse failures, clarifying that these are non-fatal and do not affect rendering.

**SVG node formatting:**
* Refactored the `Display` implementation for `Node` to reduce allocation and improve efficiency by writing attributes and children directly to the formatter.