### PR TITLE
refactor: improve buffer reading and error handling in parser

### DIFF
--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -40,13 +40,9 @@ pub fn read<R: crate::Read, const N: usize>(
 ) -> Result<([u8; N], usize), ReadError> {
     let mut buffer = [0u8; N];
 
-    match buf.read(&mut buffer) {
-        Ok(bytes_read) if bytes_read == N => Ok((buffer, N)),
-        Ok(bytes_read) => Err(ReadError::new(format!(
-            "expected {N} bytes read, but {bytes_read} bytes read"
-        ))),
-        Err(err) => Err(ReadError::new(format!("{err:?}"))),
-    }
+    read_exact(buf, &mut buffer)?;
+
+    Ok((buffer, N))
 }
 
 pub fn read_variable<R: crate::Read>(
@@ -54,18 +50,39 @@ pub fn read_variable<R: crate::Read>(
     len: usize,
 ) -> Result<(Vec<u8>, usize), ReadError> {
     if len == 0 {
-        return Ok((vec![0u8; 0], 0));
+        return Ok((Vec::new(), 0));
     }
 
     let mut buffer = vec![0u8; len];
 
-    match buf.read(&mut buffer) {
-        Ok(bytes_read) if bytes_read == len => Ok((buffer, len)),
-        Ok(bytes_read) => Err(ReadError::new(format!(
-            "expected {len} bytes read, but {bytes_read} bytes read"
-        ))),
-        Err(err) => Err(ReadError::new(format!("{err:?}"))),
+    read_exact(buf, &mut buffer)?;
+
+    Ok((buffer, len))
+}
+
+/// Reads exactly `buffer.len()` bytes from `buf`, looping to handle
+/// short reads that `embedded_io::Read` may return.
+fn read_exact<R: crate::Read>(
+    buf: &mut R,
+    buffer: &mut [u8],
+) -> Result<(), ReadError> {
+    let total = buffer.len();
+    let mut offset = 0;
+
+    while offset < total {
+        match buf.read(&mut buffer[offset..]) {
+            Ok(0) => {
+                return Err(ReadError::new(format!(
+                    "expected {total} bytes read, but {offset} bytes read \
+                     (unexpected end of stream)"
+                )));
+            }
+            Ok(n) => offset += n,
+            Err(err) => return Err(ReadError::new(format!("{err:?}"))),
+        }
     }
+
+    Ok(())
 }
 
 macro_rules! impl_from_le_bytes {

--- a/core/src/parser/objects/structure/bitmap16.rs
+++ b/core/src/parser/objects/structure/bitmap16.rs
@@ -124,8 +124,16 @@ impl Bitmap16 {
     }
 
     pub fn calc_length(&self) -> usize {
-        ((((self.width * self.bits_pixel as i16 + 15) >> 4) << 1) * self.height)
-            as usize
+        // Widen to i32 to prevent overflow.
+        // Spec: (((Width * BitsPixel + 15) >> 4) << 1) * Height
+        let w = i32::from(self.width);
+        let bp = i32::from(self.bits_pixel as u16);
+        let h = i32::from(self.height);
+
+        let row_words = (w.saturating_mul(bp).saturating_add(15)) >> 4;
+        let row_bytes = row_words << 1;
+
+        row_bytes.saturating_mul(h).unsigned_abs() as usize
     }
 }
 

--- a/core/src/parser/objects/structure/bitmap_info_header/mod.rs
+++ b/core/src/parser/objects/structure/bitmap_info_header/mod.rs
@@ -82,10 +82,15 @@ impl BitmapInfoHeader {
                 planes,
                 bit_count,
                 ..
-            }) => u32::from(
-                (((width * planes * (*bit_count as u16) + 31) & !31) / 8)
-                    * height,
-            ),
+            }) => {
+                // Widen to u32 to prevent overflow
+                let bits_per_row = u32::from(*width)
+                    .saturating_mul(u32::from(*planes))
+                    .saturating_mul(*bit_count as u32);
+                let row_bytes = ((bits_per_row.saturating_add(31)) & !31) / 8;
+
+                row_bytes.saturating_mul(u32::from(*height))
+            }
             Self::Info(BitmapInfoHeaderInfo {
                 width,
                 height,
@@ -116,13 +121,13 @@ impl BitmapInfoHeader {
                 crate::parser::Compression::BI_RGB
                 | crate::parser::Compression::BI_BITFIELDS
                 | crate::parser::Compression::BI_CMYK => {
-                    ((((*width as u32)
-                        * u32::from(*planes)
-                        * (*bit_count as u32)
-                        + 31)
-                        & !31)
-                        / 8)
-                        * height.unsigned_abs()
+                    let bits_per_row = (*width as u32)
+                        .saturating_mul(u32::from(*planes))
+                        .saturating_mul(*bit_count as u32);
+                    let row_bytes =
+                        (bits_per_row.saturating_add(31) & !31) / 8;
+
+                    row_bytes.saturating_mul(height.unsigned_abs())
                 }
                 _ => *image_size,
             },
@@ -162,9 +167,12 @@ impl BitmapInfoHeader {
             Self::Core(BitmapInfoHeaderCore { height, .. }) => {
                 usize::from(*height)
             }
+            // Use absolute value for negative height (top-down DIB)
             Self::Info(BitmapInfoHeaderInfo { height, .. })
             | Self::V4(BitmapInfoHeaderV4 { height, .. })
-            | Self::V5(BitmapInfoHeaderV5 { height, .. }) => *height as usize,
+            | Self::V5(BitmapInfoHeaderV5 { height, .. }) => {
+                height.unsigned_abs() as usize
+            }
         }
     }
 
@@ -173,9 +181,12 @@ impl BitmapInfoHeader {
             Self::Core(BitmapInfoHeaderCore { width, .. }) => {
                 usize::from(*width)
             }
+            // Use absolute value for negative width
             Self::Info(BitmapInfoHeaderInfo { width, .. })
             | Self::V4(BitmapInfoHeaderV4 { width, .. })
-            | Self::V5(BitmapInfoHeaderV5 { width, .. }) => *width as usize,
+            | Self::V5(BitmapInfoHeaderV5 { width, .. }) => {
+                width.unsigned_abs() as usize
+            }
         }
     }
 }

--- a/core/src/parser/objects/structure/device_independent_bitmap.rs
+++ b/core/src/parser/objects/structure/device_independent_bitmap.rs
@@ -99,10 +99,15 @@ impl Colors {
         color_usage: crate::parser::ColorUsage,
         dib_header_info: &crate::parser::BitmapInfoHeader,
     ) -> Result<(Self, usize), crate::parser::ParseError> {
-        assert!(matches!(
+        if !matches!(
             dib_header_info,
             crate::parser::BitmapInfoHeader::Core { .. }
-        ));
+        ) {
+            return Err(crate::parser::ParseError::UnexpectedPattern {
+                cause: "expected BitmapInfoHeader::Core variant"
+                    .to_string(),
+            });
+        }
 
         // core header does not have color_used field.
         if matches!(
@@ -125,15 +130,26 @@ impl Colors {
         color_usage: crate::parser::ColorUsage,
         dib_header_info: &crate::parser::BitmapInfoHeader,
     ) -> Result<(Self, usize), crate::parser::ParseError> {
-        assert!(matches!(
+        if !matches!(
             dib_header_info,
             crate::parser::BitmapInfoHeader::Info { .. }
                 | crate::parser::BitmapInfoHeader::V4 { .. }
                 | crate::parser::BitmapInfoHeader::V5 { .. }
-        ));
+        ) {
+            return Err(crate::parser::ParseError::UnexpectedPattern {
+                cause: "expected BitmapInfoHeader Info/V4/V5 variant"
+                    .to_string(),
+            });
+        }
 
         match dib_header_info.bit_count() {
-            crate::parser::BitCount::BI_BITCOUNT_0 => unreachable!(),
+            crate::parser::BitCount::BI_BITCOUNT_0 => {
+                Err(crate::parser::ParseError::UnexpectedPattern {
+                    cause: "BI_BITCOUNT_0 should have been handled \
+                            before reaching parse_with_info_header"
+                        .to_string(),
+                })
+            }
             crate::parser::BitCount::BI_BITCOUNT_1
             | crate::parser::BitCount::BI_BITCOUNT_2
             | crate::parser::BitCount::BI_BITCOUNT_3 => {
@@ -159,7 +175,16 @@ impl Colors {
             crate::parser::BitCount::BI_BITCOUNT_4
             | crate::parser::BitCount::BI_BITCOUNT_6 => {
                 match &dib_header_info {
-                    crate::parser::BitmapInfoHeader::Core(_) => unreachable!(),
+                    crate::parser::BitmapInfoHeader::Core(_) => {
+                        Err(
+                            crate::parser::ParseError::UnexpectedPattern {
+                                cause:
+                                    "BitmapInfoHeader::Core should not \
+                                     reach parse_with_info_header"
+                                        .to_string(),
+                            },
+                        )
+                    }
                     crate::parser::BitmapInfoHeader::Info(
                         crate::parser::BitmapInfoHeaderInfo {
                             compression, ..
@@ -246,7 +271,13 @@ impl Colors {
 
                 Ok((Colors::PaletteIndices(table), consumed_bytes))
             }
-            crate::parser::ColorUsage::DIB_PAL_INDICES => unreachable!(),
+            crate::parser::ColorUsage::DIB_PAL_INDICES => {
+                Err(crate::parser::ParseError::UnexpectedPattern {
+                    cause: "DIB_PAL_INDICES should have been handled \
+                            before reaching parse_from_color_usage"
+                        .to_string(),
+                })
+            }
         }
     }
 }

--- a/core/src/parser/objects/structure/log_color_space.rs
+++ b/core/src/parser/objects/structure/log_color_space.rs
@@ -108,7 +108,15 @@ impl LogColorSpace {
                     crate::parser::read_variable(buf, 260)?;
                 consumed_bytes += filename_bytes;
 
-                Some(String::from_utf8_lossy(&bytes).to_string())
+                // Strip trailing NUL padding from fixed-length buffer
+                let end = bytes
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(bytes.len());
+
+                Some(
+                    String::from_utf8_lossy(&bytes[..end]).to_string(),
+                )
             } else {
                 None
             };

--- a/core/src/parser/objects/structure/log_color_space.rs
+++ b/core/src/parser/objects/structure/log_color_space.rs
@@ -90,16 +90,6 @@ impl LogColorSpace {
             + gamma_green_bytes
             + gamma_blue_bytes;
 
-        let filename = if size as usize - consumed_bytes >= 260 {
-            let (bytes, filename_bytes) =
-                crate::parser::read_variable(buf, 260)?;
-            consumed_bytes += filename_bytes;
-
-            Some(String::from_utf8_lossy(&bytes).to_string())
-        } else {
-            None
-        };
-
         if signature != 0x50534F43 {
             return Err(crate::parser::ParseError::UnexpectedPattern {
                 cause: "The signature field must be 0x50534F43".to_owned(),
@@ -111,6 +101,17 @@ impl LogColorSpace {
                 cause: "The version field must be 0x00000400".to_owned(),
             });
         }
+
+        let filename =
+            if (size as usize).saturating_sub(consumed_bytes) >= 260 {
+                let (bytes, filename_bytes) =
+                    crate::parser::read_variable(buf, 260)?;
+                consumed_bytes += filename_bytes;
+
+                Some(String::from_utf8_lossy(&bytes).to_string())
+            } else {
+                None
+            };
 
         Ok((
             Self {

--- a/core/src/parser/objects/structure/log_color_space_w.rs
+++ b/core/src/parser/objects/structure/log_color_space_w.rs
@@ -90,19 +90,6 @@ impl LogColorSpaceW {
             + gamma_green_bytes
             + gamma_blue_bytes;
 
-        let filename = if size as usize - consumed_bytes >= 520 {
-            let (bytes, filename_bytes) =
-                crate::parser::read_variable(buf, 520)?;
-            consumed_bytes += filename_bytes;
-            let len = bytes.iter().position(|&c| c == 0).unwrap_or(bytes.len());
-
-            Some(crate::parser::objects::structure::utf16le_bytes_to_string(
-                &bytes[..len],
-            )?)
-        } else {
-            None
-        };
-
         if signature != 0x50534F43 {
             return Err(crate::parser::ParseError::UnexpectedPattern {
                 cause: "The signature field must be 0x50534F43".to_owned(),
@@ -114,6 +101,23 @@ impl LogColorSpaceW {
                 cause: "The version field must be 0x00000400".to_owned(),
             });
         }
+
+        let filename =
+            if (size as usize).saturating_sub(consumed_bytes) >= 520 {
+                let (bytes, filename_bytes) =
+                    crate::parser::read_variable(buf, 520)?;
+                consumed_bytes += filename_bytes;
+                let len =
+                    bytes.iter().position(|&c| c == 0).unwrap_or(bytes.len());
+
+                Some(
+                    crate::parser::objects::structure::utf16le_bytes_to_string(
+                        &bytes[..len],
+                    )?,
+                )
+            } else {
+                None
+            };
 
         Ok((
             Self {

--- a/core/src/parser/objects/structure/log_color_space_w.rs
+++ b/core/src/parser/objects/structure/log_color_space_w.rs
@@ -107,8 +107,11 @@ impl LogColorSpaceW {
                 let (bytes, filename_bytes) =
                     crate::parser::read_variable(buf, 520)?;
                 consumed_bytes += filename_bytes;
-                let len =
-                    bytes.iter().position(|&c| c == 0).unwrap_or(bytes.len());
+                // Find NUL terminator in u16 units for UTF-16LE
+                let len = bytes
+                    .chunks_exact(2)
+                    .position(|c| c == [0, 0])
+                    .map_or(bytes.len(), |pos| pos * 2);
 
                 Some(
                     crate::parser::objects::structure::utf16le_bytes_to_string(

--- a/core/src/parser/records/escape/get_color_table.rs
+++ b/core/src/parser/records/escape/get_color_table.rs
@@ -11,6 +11,16 @@ impl crate::parser::META_ESCAPE {
             crate::parser::read_u16_from_le_bytes(buf)?,
         );
         record_size.consume(byte_count_bytes + start_bytes);
+
+        if start > byte_count {
+            return Err(crate::parser::ParseError::UnexpectedPattern {
+                cause: format!(
+                    "start `{start:#06X}` exceeds \
+                     byte_count `{byte_count:#06X}`",
+                ),
+            });
+        }
+
         let (_, c) = crate::parser::read_variable(buf, start as usize)?;
         record_size.consume(c);
 

--- a/core/src/parser/records/mod.rs
+++ b/core/src/parser/records/mod.rs
@@ -57,23 +57,8 @@ fn consume_remaining_bytes<R: crate::Read>(
     while discarded < remaining {
         let to_read = core::cmp::min(remaining - discarded, chunk.len());
 
-        match buf.read(&mut chunk[..to_read]) {
-            Ok(n) if n == to_read => discarded += n,
-            Ok(n) => {
-                return Err(crate::parser::ParseError::FailedReadBuffer {
-                    cause: crate::parser::ReadError::new(alloc::format!(
-                        "expected {to_read} bytes read, but {n} bytes read"
-                    )),
-                });
-            }
-            Err(err) => {
-                return Err(crate::parser::ParseError::FailedReadBuffer {
-                    cause: crate::parser::ReadError::new(alloc::format!(
-                        "{err:?}"
-                    )),
-                });
-            }
-        }
+        crate::parser::read_exact(buf, &mut chunk[..to_read])?;
+        discarded += to_read;
     }
 
     Ok((crate::imports::Vec::new(), discarded))


### PR DESCRIPTION
This pull request focuses on improving the robustness and correctness of bitmap parsing and reading logic, particularly around byte reading, overflow prevention, and error handling. The changes address subtle bugs related to buffer reads, integer overflows, and error reporting, leading to safer and more maintainable code.

**Byte reading and error handling improvements:**

- Refactored the `read` and `read_variable` functions in `core/src/parser/mod.rs` to use a new helper function `read_exact`, which ensures that the expected number of bytes are read, looping as necessary to handle short reads. This makes buffer reading more reliable and error messages more precise. (`[core/src/parser/mod.rsL43-R87](diffhunk://#diff-031fc99e5382f7d8a1f7f916ab17319bf5fb014833ab5461d9ecef53225b4da0L43-R87)`)
- Updated `consume_remaining_bytes` in `core/src/parser/records/mod.rs` to use the new `read_exact` function, simplifying logic and improving error handling for incomplete reads. (`[core/src/parser/records/mod.rsL60-R61](diffhunk://#diff-301d5d5dd666f971a7b1cfad36817a16403598c4fc66ab00f657ff4b3a715f2aL60-R61)`)

**Overflow and bounds safety in bitmap size calculations:**

- Modified bitmap size and row calculations in `Bitmap16` (`core/src/parser/objects/structure/bitmap16.rs`) and `BitmapInfoHeader` (`core/src/parser/objects/structure/bitmap_info_header/mod.rs`) to use wider integer types (`i32`, `u32`) and saturating arithmetic, preventing overflows and handling negative dimensions more safely. (`[[1]](diffhunk://#diff-c317ea0ad20f6bd924fe877e4ea4f7ba9cac9adf3ee4c269590fe07fd1e9810eL127-R136)`, `[[2]](diffhunk://#diff-de0f18d09c429c12ccea9d6907847e98357eccc5bcdbb7553c0447af47b5a686L85-R93)`, `[[3]](diffhunk://#diff-de0f18d09c429c12ccea9d6907847e98357eccc5bcdbb7553c0447af47b5a686L119-R130)`)
- Updated height and width accessors in `BitmapInfoHeader` to use unsigned absolute values, ensuring correct handling of negative (top-down) DIB dimensions. (`[[1]](diffhunk://#diff-de0f18d09c429c12ccea9d6907847e98357eccc5bcdbb7553c0447af47b5a686R170-R175)`, `[[2]](diffhunk://#diff-de0f18d09c429c12ccea9d6907847e98357eccc5bcdbb7553c0447af47b5a686R184-R189)`)

**Parsing logic and error reporting enhancements:**

- Replaced `assert!` and `unreachable!()` macros with explicit error returns in `Colors` parsing logic (`core/src/parser/objects/structure/device_independent_bitmap.rs`), resulting in clearer and more user-friendly error messages when encountering unexpected header variants or bit counts. (`[[1]](diffhunk://#diff-471c6e2a7e12947dc7e338c372c9049d20521cc26759fc8b6b1762cb597ff45fL102-R110)`, `[[2]](diffhunk://#diff-471c6e2a7e12947dc7e338c372c9049d20521cc26759fc8b6b1762cb597ff45fL128-R152)`, `[[3]](diffhunk://#diff-471c6e2a7e12947dc7e338c372c9049d20521cc26759fc8b6b1762cb597ff45fL162-R187)`, `[[4]](diffhunk://#diff-471c6e2a7e12947dc7e338c372c9049d20521cc26759fc8b6b1762cb597ff45fL249-R280)`)
- Added a validation check in `META_ESCAPE::get_color_table` to ensure the `start` offset does not exceed the `byte_count`, returning a descriptive error if the condition is violated. (`[core/src/parser/records/escape/get_color_table.rsR14-R23](diffhunk://#diff-7ca0904270e4b90fee554cf92b2b93c0b7451f2bf03de7d5061be6f9855ad685R14-R23)`)

**Miscellaneous improvements:**

- Adjusted logic for parsing optional filenames in `LogColorSpace` and `LogColorSpaceW` to use `saturating_sub` for safer bounds checking. (`[[1]](diffhunk://#diff-fae6cabe9b7a483ef5cb3267aa66a0343dd64f86b4d5c6be3e9b89704aa81423L93-L102)`, `[[2]](diffhunk://#diff-fae6cabe9b7a483ef5cb3267aa66a0343dd64f86b4d5c6be3e9b89704aa81423R105-R115)`, `[[3]](diffhunk://#diff-5b8a4346aeae7b3991a8da067bdf0728a26b0e5509730a351d7ee7580936f3a1L93-L105)`, `[[4]](diffhunk://#diff-5b8a4346aeae7b3991a8da067bdf0728a26b0e5509730a351d7ee7580936f3a1R105-R121)`)