### PR TITLE
fix: render META_POLYPOLYGON as a single path so holes subtract

### DIFF
--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -1336,6 +1336,12 @@ impl crate::converter::Player for SVGPlayer {
         let mut a_point: VecDeque<_> = record.poly_polygon.a_points.into();
         let total_points = a_point.len();
 
+        // Emit all sub-polygons as a single path with multiple subpaths so
+        // the fill-rule (evenodd / nonzero) can subtract inner rings from
+        // outer rings — required for glyphs and shapes with holes.
+        let mut data = Data::new();
+        let mut emitted = false;
+
         for i in 0..record.poly_polygon.number_of_polygons {
             let Some(points_of_polygon) =
                 record.poly_polygon.a_points_per_polygon.get(i as usize)
@@ -1345,9 +1351,11 @@ impl crate::converter::Player for SVGPlayer {
                 });
             };
 
-            let mut points = Vec::with_capacity(*points_of_polygon as usize);
+            if *points_of_polygon == 0 {
+                continue;
+            }
 
-            for _ in 0..*points_of_polygon {
+            for j in 0..*points_of_polygon {
                 let Some(point) = a_point.pop_front() else {
                     return Err(PlayError::InvalidRecord {
                         cause: format!(
@@ -1358,17 +1366,29 @@ impl crate::converter::Player for SVGPlayer {
                 };
 
                 let point = self.convert_point(point.x, point.y);
-                points.push(as_point_string(&point));
+                let coord = as_point_string(&point);
+                data = if j == 0 {
+                    data.move_to(coord)
+                } else {
+                    data.line_to(coord)
+                };
             }
 
-            let polygon = Node::new("polygon")
-                .set("fill", fill.as_str())
-                .set("fill-rule", fill_rule)
-                .set("points", points.join(" "));
-            let polygon = stroke.set_props(polygon);
-
-            self.push_element(record_number, polygon);
+            data = data.close();
+            emitted = true;
         }
+
+        if !emitted {
+            return Ok(self);
+        }
+
+        let path = Node::new("path")
+            .set("fill", fill.as_str())
+            .set("fill-rule", fill_rule)
+            .set("d", data);
+        let path = stroke.set_props(path);
+
+        self.push_element(record_number, path);
 
         Ok(self)
     }

--- a/core/tests/drawing/mod.rs
+++ b/core/tests/drawing/mod.rs
@@ -1,1 +1,2 @@
 mod chord;
+mod poly_polygon;

--- a/core/tests/drawing/poly_polygon.rs
+++ b/core/tests/drawing/poly_polygon.rs
@@ -1,0 +1,128 @@
+use wmf_core::{
+    converter::{Player, SVGPlayer},
+    parser::{
+        META_POLYPOLYGON, META_SETPOLYFILLMODE, META_SETWINDOWEXT, PointS,
+        PolyFillMode, PolyPolygon,
+    },
+};
+
+#[test]
+fn meta_poly_polygon_svg_table_test() {
+    struct TestCase {
+        desc: &'static str,
+        fill_mode: PolyFillMode,
+        record: META_POLYPOLYGON,
+        expected_svg: &'static str,
+    }
+
+    // Outer square + inner square — the "donut" / glyph-hole case that
+    // regressed numbers like "0" in CHEQBOOK.WMF. The two sub-polygons MUST
+    // be emitted as one <path> with two subpaths so fill-rule can subtract
+    // the inner ring from the outer.
+    let donut = || META_POLYPOLYGON {
+        record_size: 0.into(),
+        record_function: 0,
+        poly_polygon: PolyPolygon {
+            number_of_polygons: 2,
+            a_points_per_polygon: vec![4, 4],
+            a_points: vec![
+                PointS { x: 10, y: 10 },
+                PointS { x: 90, y: 10 },
+                PointS { x: 90, y: 90 },
+                PointS { x: 10, y: 90 },
+                PointS { x: 30, y: 30 },
+                PointS { x: 70, y: 30 },
+                PointS { x: 70, y: 70 },
+                PointS { x: 30, y: 70 },
+            ],
+        },
+    };
+
+    let cases = [
+        TestCase {
+            desc: "Outer + inner ring (evenodd) emits one path with two \
+                   subpaths",
+            fill_mode: PolyFillMode::ALTERNATE,
+            record: donut(),
+            expected_svg: r##"<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path d="M 10,10 L 90,10 L 90,90 L 10,90 Z M 30,30 L 70,30 L 70,70 L 30,70 Z" fill="none" fill-rule="evenodd" id="elem1" stroke="#000000" stroke-dasharray="none" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1.00" stroke-width="1"></path></svg>"##,
+        },
+        TestCase {
+            desc: "Outer + inner ring (nonzero) carries the winding \
+                   fill-rule",
+            fill_mode: PolyFillMode::WINDING,
+            record: donut(),
+            expected_svg: r##"<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path d="M 10,10 L 90,10 L 90,90 L 10,90 Z M 30,30 L 70,30 L 70,70 L 30,70 Z" fill="none" fill-rule="nonzero" id="elem1" stroke="#000000" stroke-dasharray="none" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1.00" stroke-width="1"></path></svg>"##,
+        },
+        TestCase {
+            desc: "Single sub-polygon still produces a single path",
+            fill_mode: PolyFillMode::ALTERNATE,
+            record: META_POLYPOLYGON {
+                record_size: 0.into(),
+                record_function: 0,
+                poly_polygon: PolyPolygon {
+                    number_of_polygons: 1,
+                    a_points_per_polygon: vec![3],
+                    a_points: vec![
+                        PointS { x: 0, y: 0 },
+                        PointS { x: 100, y: 0 },
+                        PointS { x: 50, y: 100 },
+                    ],
+                },
+            },
+            expected_svg: r##"<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path d="M 0,0 L 100,0 L 50,100 Z" fill="none" fill-rule="evenodd" id="elem1" stroke="#000000" stroke-dasharray="none" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1.00" stroke-width="1"></path></svg>"##,
+        },
+        TestCase {
+            desc: "Zero-point sub-polygon is skipped without consuming \
+                   subsequent points",
+            fill_mode: PolyFillMode::ALTERNATE,
+            record: META_POLYPOLYGON {
+                record_size: 0.into(),
+                record_function: 0,
+                poly_polygon: PolyPolygon {
+                    number_of_polygons: 2,
+                    a_points_per_polygon: vec![0, 3],
+                    a_points: vec![
+                        PointS { x: 0, y: 0 },
+                        PointS { x: 10, y: 0 },
+                        PointS { x: 5, y: 10 },
+                    ],
+                },
+            },
+            expected_svg: r##"<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path d="M 0,0 L 10,0 L 5,10 Z" fill="none" fill-rule="evenodd" id="elem1" stroke="#000000" stroke-dasharray="none" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1.00" stroke-width="1"></path></svg>"##,
+        },
+    ];
+
+    for (i, case) in cases.iter().enumerate() {
+        let player = SVGPlayer::new();
+        let player = player
+            .set_window_ext(0, META_SETWINDOWEXT {
+                record_size: 0.into(),
+                record_function: 0,
+                y: 1024,
+                x: 1024,
+            })
+            .expect("set_window_ext failed");
+        let player = player
+            .set_polyfill_mode(0, META_SETPOLYFILLMODE {
+                record_size: 0.into(),
+                record_function: 0,
+                poly_fill_mode: case.fill_mode,
+                reserved: None,
+            })
+            .expect("set_polyfill_mode failed");
+        let result = player.poly_polygon(1, case.record.clone());
+
+        assert!(result.is_ok(), "case {i}: {}: Rendering failed", case.desc);
+
+        let player = result.unwrap();
+        let svg = player.generate().expect("SVG generation failed");
+        let svg_str = String::from_utf8(svg).expect("SVG output is not UTF-8");
+
+        assert_eq!(
+            svg_str.trim(),
+            case.expected_svg.trim(),
+            "case {i}: {}: SVG output does not match expected",
+            case.desc,
+        );
+    }
+}


### PR DESCRIPTION
I've checked this gives sensible results on the WMFs which were causing problems in #36 but I'm not absolutely certain that it's the right solution. Comments welcome.

Each sub-polygon of a POLYPOLYGON was being emitted as its own <polygon> element, which stripped the fill-rule's ability to subtract inner rings from outer rings. Glyph holes (the inside of 0, 6, 8, 9) and any other compound shape came out filled solid.

Emit all sub-polygons as one <path> with M...L...Z subpaths so evenodd/nonzero fill-rule correctly handles holes.

Fixes #36 