### PR TITLE
fix(svg): emit unique element ids and valid font-weight values

### DIFF
--- a/core/src/converter/svg/mod.rs
+++ b/core/src/converter/svg/mod.rs
@@ -28,6 +28,10 @@ pub struct SVGPlayer {
     elements: Vec<Node>,
     object_selected: SelectedGraphicsObject,
     current_clip_id: Option<String>,
+    // Tracks how many elements have been emitted per WMF record so that
+    // `id` attributes stay unique when a single record produces multiple
+    // SVG elements (e.g. POLYPOLYGON emits one polygon per sub-polygon).
+    record_element_counts: BTreeMap<usize, usize>,
 }
 
 impl SVGPlayer {
@@ -43,7 +47,18 @@ impl SVGPlayer {
     #[inline]
     fn push_element(&mut self, record_number: usize, mut element: Node) {
         if record_number > 0 {
-            element = element.set("id", format!("elem{record_number}"));
+            // Append a suffix to second and later elements from the same
+            // record to satisfy the SVG `id` uniqueness constraint.
+            let count =
+                self.record_element_counts.entry(record_number).or_insert(0);
+            let id = if *count == 0 {
+                format!("elem{record_number}")
+            } else {
+                format!("elem{record_number}-{count}")
+            };
+
+            *count += 1;
+            element = element.set("id", id);
         }
 
         if let Some(ref clip_id) = self.current_clip_id {

--- a/core/src/converter/svg/util.rs
+++ b/core/src/converter/svg/util.rs
@@ -330,8 +330,52 @@ impl Font {
         elem = elem
             .set("font-family", format!("'{}'", font_family.join("','")))
             .set("font-size", self.height.abs())
-            .set("font-weight", self.weight);
+            .set("font-weight", Self::svg_font_weight(self.weight));
 
         (elem, styles)
+    }
+
+    /// Convert a WMF `Font.weight` (0..=1000, where 0 is FW_DONTCARE) into a
+    /// value accepted by SVG 1.1. SVG 1.1 only allows numeric weights at
+    /// multiples of 100 in 100..=900 or keywords such as `normal`, so map
+    /// FW_DONTCARE to `normal` and snap any other value to the nearest
+    /// hundred, clamped into 100..=900.
+    fn svg_font_weight(weight: i16) -> String {
+        if weight == 0 {
+            return "normal".to_owned();
+        }
+
+        let snapped = (i32::from(weight) + 50) / 100 * 100;
+        format!("{}", snapped.clamp(100, 900))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn svg_font_weight_maps_dontcare_to_normal() {
+        assert_eq!(Font::svg_font_weight(0), "normal");
+    }
+
+    #[test]
+    fn svg_font_weight_passes_through_canonical_values() {
+        assert_eq!(Font::svg_font_weight(400), "400");
+        assert_eq!(Font::svg_font_weight(700), "700");
+    }
+
+    #[test]
+    fn svg_font_weight_snaps_to_nearest_hundred() {
+        assert_eq!(Font::svg_font_weight(350), "400");
+        assert_eq!(Font::svg_font_weight(349), "300");
+    }
+
+    #[test]
+    fn svg_font_weight_clamps_out_of_range() {
+        assert_eq!(Font::svg_font_weight(50), "100");
+        assert_eq!(Font::svg_font_weight(950), "900");
+        assert_eq!(Font::svg_font_weight(1000), "900");
+        assert_eq!(Font::svg_font_weight(-1), "100");
     }
 }


### PR DESCRIPTION
## Summary

Fixes two SVG validation errors detected by the W3C Nu validator (`vnu`) on `wmf-cli` output:

- Duplicate `id` values when one WMF record emits multiple SVG elements (e.g. `META_POLYPOLYGON`, `META_PIE`).
- Invalid `font-weight="0"` (WMF `FW_DONTCARE`) which SVG 1.1 does not accept.

## Changes

- `core/src/converter/svg/mod.rs`
  - Add `record_element_counts: BTreeMap<usize, usize>` to `SVGPlayer`.
  - In `push_element`, increment the counter per `record_number`. The first emission keeps `id="elem{N}"`; subsequent ones get `id="elem{N}-1"`, `id="elem{N}-2"`, and so on.
- `core/src/converter/svg/util.rs`
  - Add `Font::svg_font_weight(weight: i16) -> String`. Map `0` (FW_DONTCARE) to `"normal"`; snap any other value to the nearest multiple of 100 and clamp into `100..=900`.
  - Switch the `font-weight` attribute output to use this helper.
  - Add unit tests covering FW_DONTCARE, canonical values, snapping, and clamping (negative / over-range inputs).
