### PR TITLE
chore: harden workflows and broaden Dependabot coverage

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,10 +9,34 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     steps:
-      - uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.3
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+        with:
+          persist-credentials: false
       - run: "rustup component add --toolchain nightly rustfmt"
       - run: "make fmt"
 
@@ -28,7 +30,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     steps:
-      - uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.3
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+        with:
+          persist-credentials: false
       - run: "rustup component add clippy"
       - run: "make lint"
 
@@ -37,7 +41,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     steps:
-      - uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.3
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+        with:
+          persist-credentials: false
       - run: "make spell-check"
 
   testing:
@@ -45,5 +51,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     steps:
-      - uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.3
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+        with:
+          persist-credentials: false
       - run: "make test"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,19 +10,24 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: "write"
+  contents: "read"
 
 jobs:
   publish-wasm:
     name: "Build and publish wasm artifacts"
     runs-on: "ubuntu-latest"
     timeout-minutes: 20
+    permissions:
+      contents: "write"
     steps:
-      - uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.3
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+        with:
+          persist-credentials: false
+
       - uses: "cargo-bins/cargo-binstall@30b5ca8b54e1dcffd9548bc87ede1531310fdc67" # v1.20.0
 
       - name: "Install wasm tooling"
-        run: "cargo binstall -y wasm-bindgen-cli wasm-opt wasm-pack"
+        run: "cargo binstall -y --locked wasm-bindgen-cli wasm-opt wasm-pack"
 
       - name: "Build wasm (full)"
         run: "make wasm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -182,9 +182,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "embedded-io"
@@ -251,9 +248,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -289,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minicov"
@@ -474,9 +471,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snafu"
@@ -528,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -548,12 +545,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -563,15 +559,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -692,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -705,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -715,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -725,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -738,18 +734,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.73"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28a0782b173cf2e98f62aacb487c5c021b7c5925df46098675f28e1fa85e159"
+checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
 dependencies = [
  "async-trait",
  "cast",
@@ -769,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.73"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee997551ce1ad5adda03f7ce37ec34b4140fe9f547fd07b46d55901d1ba1a06b"
+checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -780,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0f005eb61f765eff31a79ef71df7e21819731268a868df41192c1e41d6d3e5"
+checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 tracing-wasm = "0.2.1"
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
-wasm-bindgen = "0.2.123"
-wasm-bindgen-test = "0.3.73"
+wasm-bindgen = "0.2.125"
+wasm-bindgen-test = "0.3.75"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ wasm:
 	cd wasm && wasm-pack build \
 		--out-dir dist \
 		--release \
-		--target web
+		--target web \
+		-- --locked
 
 # Minimal build with the `tracing` feature stripped. Drops the
 # `tracing-wasm` dependency entirely, which yields a noticeably smaller
@@ -99,4 +100,4 @@ wasm-minimal:
 		--out-dir dist-minimal \
 		--release \
 		--target web \
-		-- --no-default-features --features console_error_panic_hook
+		-- --locked --no-default-features --features console_error_panic_hook


### PR DESCRIPTION
## Summary

Routine maintenance pass covering three orthogonal areas:

1. **Dependency bumps** — `wasm-bindgen` 0.2.123 → 0.2.125 and `wasm-bindgen-test` 0.3.73 → 0.3.75, with the matching `Cargo.lock` refresh (transitive bumps for `cc`, `js-sys`, `memchr`, `smallvec`, `syn`, `time`, `time-core`, `time-macros`, `wasm-bindgen-*`).
2. **CI/release workflow hardening** — tighten token handling and permission scope, and make release builds reproducible.
3. **Dependabot coverage** — track Docker and npm ecosystems, group per-ecosystem updates to cut PR volume.

## Workflow hardening

### `actions/checkout` — `persist-credentials: false`

All checkout invocations in `ci.yaml` and `release.yaml` now disable the credential helper. By default `actions/checkout` writes `GITHUB_TOKEN` into the runner's `.git/config`, where it remains readable by every subsequent step (`make`, `cargo`, `wasm-pack`, `docker`). None of these jobs push back to the remote, so dropping the credential is loss-free and removes a token-leak surface.

### `release.yaml` — least-privilege permissions

Workflow scope drops to `contents: read`. The `publish-wasm` job opts in to `contents: write` for `gh release create`/`upload`. New jobs added later default to read-only and must opt in explicitly, instead of inheriting write access from the workflow scope.

### Reproducible release builds

- `cargo binstall` now runs with `--locked` so the tool's own dependency resolution does not drift between runs.
- `wasm-pack build` (both the `wasm` and `wasm-minimal` Makefile targets) passes `-- --locked`. Release artifacts now match the committed `Cargo.lock` instead of silently resolving newer semver-compatible versions at build time.

## Dependabot

- Add `docker` for `/docker` — the Dockerfile base image was previously unmonitored.
- Add `npm` for `/` — covers the demo `serve` dev dependency.
- Group every ecosystem's updates with `patterns: ["*"]` so updates arrive as a single per-ecosystem PR rather than one PR per crate.
- Drop the redundant `target-branch: "master"` (it matched the default already).

## Dependency bumps

`Cargo.toml`:

- `wasm-bindgen` 0.2.123 → 0.2.125
- `wasm-bindgen-test` 0.3.73 → 0.3.75

`Cargo.lock` follows along, picking up the matching `wasm-bindgen-*` family and routine transitive updates (`cc`, `js-sys`, `memchr`, `smallvec`, `syn`, `time`, `time-core`,
`time-macros`).
